### PR TITLE
feat(get_subgraph): Optionally retrieve intermediate layer nodes

### DIFF
--- a/pychunkedgraph/app/cg_app_blueprint.py
+++ b/pychunkedgraph/app/cg_app_blueprint.py
@@ -240,9 +240,9 @@ def handle_leaves(root_id):
 
     # Call ChunkedGraph
     cg = app_utils.get_cg()
-    atomic_ids = cg.get_subgraph(int(root_id),
-                                 bounding_box=bounding_box,
-                                 bb_is_coordinate=True)
+    atomic_ids = cg.get_subgraph_nodes(int(root_id),
+                                       bounding_box=bounding_box,
+                                       bb_is_coordinate=True)
 
     # Return binary
     return app_utils.tobinary(atomic_ids)
@@ -262,9 +262,9 @@ def handle_leaves_from_leave(atomic_id):
     cg = app_utils.get_cg()
     root_id = cg.get_root(int(atomic_id))
 
-    atomic_ids = cg.get_subgraph(root_id,
-                                 bounding_box=bounding_box,
-                                 bb_is_coordinate=True)
+    atomic_ids = cg.get_subgraph_nodes(root_id,
+                                       bounding_box=bounding_box,
+                                       bb_is_coordinate=True)
     # Return binary
     return app_utils.tobinary(np.concatenate([np.array([root_id]), atomic_ids]))
 
@@ -280,9 +280,8 @@ def handle_subgraph(root_id):
 
     # Call ChunkedGraph
     cg = app_utils.get_cg()
-    atomic_edges = cg.get_subgraph(int(root_id),
-                                   get_edges=True,
-                                   bounding_box=bounding_box,
-                                   bb_is_coordinate=True)[0]
+    atomic_edges = cg.get_subgraph_edges(int(root_id),
+                                         bounding_box=bounding_box,
+                                         bb_is_coordinate=True)[0]
     # Return binary
     return app_utils.tobinary(atomic_edges)

--- a/pychunkedgraph/benchmarking/simulator.py
+++ b/pychunkedgraph/benchmarking/simulator.py
@@ -133,9 +133,12 @@ class ChunkedGraphSimulator(object):
         np.random.shuffle(root_ids)
 
         for root_id in root_ids[: n_tests]:
-            dt, _ = measure_command(self.cg.get_subgraph,
-                                    {"agglomeration_id": int(root_id),
-                                     "get_edges": get_edges})
+            if get_edges:
+                dt, _ = measure_command(self.cg.get_subgraph_edges,
+                                        {"agglomeration_id": int(root_id)})
+            else:
+                dt, _ = measure_command(self.cg.get_subgraph_nodes,
+                                        {"agglomeration_id": int(root_id)})
 
             times.append(dt)
 

--- a/pychunkedgraph/creator/graph_tests.py
+++ b/pychunkedgraph/creator/graph_tests.py
@@ -115,7 +115,7 @@ def root_cross_edge_test(node_id, table_id=None, cg=None):
     cross_edge_dict_layers = {}
     cross_edge_dict_children = {}
     for layer in range(2, cg.n_layers):
-        child_ids = cg.get_subgraph(node_id, stop_lvl=layer)
+        child_ids = cg.get_subgraph_nodes(node_id, return_layers=[layer])
 
         cross_edge_dict = {}
         child_reference_ids = []

--- a/pychunkedgraph/exporting/export.py
+++ b/pychunkedgraph/exporting/export.py
@@ -48,8 +48,8 @@ def get_sv_to_root_id_mapping_chunk(cg, chunk_coords, vol=None):
         sv_to_root_mapping[atomic_id] = root_id
 
         # Add atomic children of root_id
-        atomic_ids = cg.get_subgraph(root_id, bounding_box=bb,
-                                     bb_is_coordinate=False)
+        atomic_ids = cg.get_subgraph_nodes(root_id, bounding_box=bb,
+                                           bb_is_coordinate=False)
         sv_to_root_mapping.update(dict(zip(atomic_ids,
                                            [root_id] * len(atomic_ids))))
 

--- a/pychunkedgraph/meshing/meshgen.py
+++ b/pychunkedgraph/meshing/meshgen.py
@@ -429,7 +429,7 @@ def mesh_lvl2_preview(cg, lvl2_node_id, cv_path=None, cv_mesh_dir=None,
     if cv_path is None:
         cv_path = cg.cv_path
 
-    supervoxel_ids = cg.get_subgraph(lvl2_node_id, verbose=verbose)
+    supervoxel_ids = cg.get_subgraph_nodes(lvl2_node_id, verbose=verbose)
     remap_table = dict(zip(supervoxel_ids, [lvl2_node_id] * len(supervoxel_ids)))
 
     mesh_block_shape = get_mesh_block_shape(cg, layer, mip)


### PR DESCRIPTION
* Splits `get_subgraph` into `get_subgraph_nodes` and `get_subgraph_edges` (previously, return type and most of the code path changed based on the `get_edges` parameter, anyway)
* Extends `stop_layer` to `return_layers` parameter, which enables users to retrieve all intermediate nodes along the path to the leaf layer. (Useful for remeshing all nodes within a subgraph)
* Added tests for both functions. Fixed minor issues. **get_subgraph_edges still returns duplicate edges**
* No performance decline (or improvement) detected.