### PR TITLE
refactor(logging): Use logging for app, core and core tests

### DIFF
--- a/pychunkedgraph/app/__init__.py
+++ b/pychunkedgraph/app/__init__.py
@@ -1,8 +1,10 @@
 from flask import Flask
+from flask.logging import default_handler
 from flask_cors import CORS
 import sys
 import logging
 import os
+import time
 
 from . import config
 
@@ -10,6 +12,7 @@ from . import config
 from pychunkedgraph.app import cg_app_blueprint, meshing_app_blueprint
 # from pychunkedgraph.app import manifest_app_blueprint
 os.environ['TRAVIS_BRANCH'] = "IDONTKNOWWHYINEEDTHIS"
+
 
 def create_app(test_config=None):
     app = Flask(__name__)
@@ -28,7 +31,6 @@ def create_app(test_config=None):
 
 
 def configure_app(app):
-
     # Load logging scheme from config.py
     app.config.from_object(config.BaseConfig)
 
@@ -36,8 +38,12 @@ def configure_app(app):
     # handler = logging.FileHandler(app.config['LOGGING_LOCATION'])
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(app.config['LOGGING_LEVEL'])
-    formatter = logging.Formatter(app.config['LOGGING_FORMAT'])
+    formatter = logging.Formatter(
+        app.config['LOGGING_FORMAT'],
+        app.config['LOGGING_DATEFORMAT'])
+    formatter.converter = time.gmtime
     handler.setFormatter(formatter)
+    app.logger.removeHandler(default_handler)
     app.logger.addHandler(handler)
-
-
+    app.logger.setLevel(app.config['LOGGING_LEVEL'])
+    app.logger.propagate = False

--- a/pychunkedgraph/app/cg_app_blueprint.py
+++ b/pychunkedgraph/app/cg_app_blueprint.py
@@ -43,7 +43,7 @@ def home():
 
 @bp.before_request
 def before_request():
-    # print("NEW REQUEST:", datetime.now(), request.url)
+    # current_app.logger.debug(("NEW REQUEST:", datetime.now(), request.url))
     current_app.request_start_time = time.time()
     current_app.request_start_date = datetime.utcnow()
 
@@ -60,7 +60,7 @@ def after_request(response):
     #                        response_time=dt, url=request.url,
     #                        request_data=request.data)
 
-    print("Response time: %.3fms" % dt)
+    current_app.logger.debug("Response time: %.3fms" % dt)
     return response
 
 
@@ -82,8 +82,7 @@ def unhandled_exception(e):
 
     tb = traceback.format_exception(etype=type(e), value=e,
                                     tb=e.__traceback__)
-    print(tb)
-    print("Response time: %.3fms" % dt)
+    current_app.logger.error(json.dumps(tb))
 
     resp = {
         'timestamp': current_app.request_start_date,
@@ -100,8 +99,7 @@ def unhandled_exception(e):
 def api_exception(e):
     dt = (time.time() - current_app.request_start_time) * 1000
 
-    print(str(e))
-    print("Response time: %.3fms" % dt)
+    current_app.logger.error(str(e))
 
     resp = {
         'timestamp': current_app.request_start_date,
@@ -227,7 +225,7 @@ def handle_split():
 
     user_id = str(request.remote_addr)
 
-    print(data)
+    current_app.logger.debug(data)
 
     # Call ChunkedGraph
     cg = app_utils.get_cg()
@@ -245,7 +243,7 @@ def handle_split():
 
             coordinate = np.array([x, y, z])
 
-            print("before", coordinate)
+            current_app.logger.debug(("before", coordinate))
 
             if not cg.is_in_bounds(coordinate):
                 coordinate /= cg.segmentation_resolution
@@ -253,7 +251,7 @@ def handle_split():
                 coordinate[0] *= 2
                 coordinate[1] *= 2
 
-            print("after", coordinate)
+            current_app.logger.debug(("after", coordinate))
 
             atomic_id = cg.get_atomic_id_from_coord(coordinate[0],
                                                     coordinate[1],
@@ -268,7 +266,7 @@ def handle_split():
             data_dict[k]["id"].append(atomic_id)
             data_dict[k]["coord"].append(coordinate)
 
-    print(data_dict)
+    current_app.logger.debug(data_dict)
 
     try:
         new_roots = cg.remove_edges(user_id=user_id,
@@ -289,7 +287,7 @@ def handle_split():
             "Could not split selected segment groups."
         )
 
-    print("after split:", new_roots)
+    current_app.logger.debug(("after split:", new_roots))
 
     # Return binary
     return app_utils.tobinary(new_roots)
@@ -301,7 +299,7 @@ def handle_shatter():
 
     user_id = str(request.remote_addr)
 
-    print(data)
+    current_app.logger.debug(data)
 
     # Call ChunkedGraph
     cg = app_utils.get_cg()
@@ -320,7 +318,7 @@ def handle_shatter():
 
     coordinate = np.array([x, y, z])
 
-    print("before", coordinate)
+    current_app.logger.debug(("before", coordinate))
 
     if not cg.is_in_bounds(coordinate):
         coordinate /= cg.segmentation_resolution
@@ -328,7 +326,7 @@ def handle_shatter():
         coordinate[0] *= 2
         coordinate[1] *= 2
 
-    print("after", coordinate)
+    current_app.logger.debug(("after", coordinate))
 
     atomic_id = cg.get_atomic_id_from_coord(coordinate[0],
                                             coordinate[1],
@@ -344,7 +342,7 @@ def handle_shatter():
     data_dict["id"].append(atomic_id)
     data_dict["coord"].append(coordinate)
 
-    print(data_dict)
+    current_app.logger.debug(data_dict)
     try:
         new_roots = cg.shatter_nodes(user_id=user_id,
                                      atomic_node_ids=data_dict['id'],

--- a/pychunkedgraph/app/config.py
+++ b/pychunkedgraph/app/config.py
@@ -8,9 +8,13 @@ class BaseConfig(object):
     HOME = os.path.expanduser("~")
     # TODO get this secret out of source control
     SECRET_KEY = '1d94e52c-1c89-4515-b87a-f48cf3cb7f0b'
-    LOGGING_FORMAT = '%(asctime)s - %(levelname)s - %(message)s'
 
+    LOGGING_FORMAT = '{"source":"%(name)s","time":"%(asctime)s","severity":"%(levelname)s","message":"%(message)s"}'
+    LOGGING_DATEFORMAT = '%Y-%m-%dT%H:%M:%S.0Z'
     LOGGING_LEVEL = logging.DEBUG
+
+    CHUNKGRAPH_INSTANCE_ID = "pychunkedgraph"
+
     # TODO what is this suppose to be by default?
     CHUNKGRAPH_TABLE_ID = "pinky100_sv16"
     # CHUNKGRAPH_TABLE_ID = "pinky100_benchmark_v92"

--- a/pychunkedgraph/backend/chunkedgraph_comp.py
+++ b/pychunkedgraph/backend/chunkedgraph_comp.py
@@ -70,7 +70,7 @@ def get_latest_roots(cg,
     if n_threads == 1:
         results = mu.multiprocess_func(_read_root_rows_thread,
                                        multi_args, n_threads=n_threads,
-                                       verbose=True, debug=n_threads==1)
+                                       verbose=False, debug=n_threads==1)
     else:
         results = mu.multisubprocess_func(_read_root_rows_thread,
                                           multi_args, n_threads=n_threads)

--- a/pychunkedgraph/meshing/meshgen.py
+++ b/pychunkedgraph/meshing/meshgen.py
@@ -383,7 +383,7 @@ def mesh_lvl2_previews(cg, lvl2_node_ids, cv_path=None,
     if n_threads == 1:
         mu.multiprocess_func(_mesh_lvl2_previews_threads,
                              multi_args, n_threads=n_threads,
-                             verbose=True, debug=n_threads==1)
+                             verbose=False, debug=n_threads==1)
     else:
         mu.multisubprocess_func(_mesh_lvl2_previews_threads,
                                 multi_args, n_threads=n_threads)

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -75,3 +75,15 @@ memory-report = true
 
 # Additional log output for harakiri
 harakiri-verbose = true
+
+
+### Logging
+# Filter our own pre-formated app messages and pass them through
+logger = applog stdio
+log-route = applog "source":
+
+# Unnamed logger catches everything else (uwsgi + unknown) and wrap it
+# in a single JSON+newline for fluentd to process
+logger = stdio
+log-encoder = json {"source":"uWSGI","time":"${strftime:%Y-%m-%dT%H:%M:%S.000Z}","severity":"info","message":"${msg}"}
+log-encoder = nl


### PR DESCRIPTION
Part of the large logging overhaul of the AnnotationFrameworkDeployment / PyChunkedGraph.
Problems this PR resolves / prepares to resolve:
  - All debug print messages ended up as `ERROR` in Stackdriver.
  - No easy way to tell which process/module reported which error

Details:
- Replaced `print` statements with logging (`ChunkedGraph` class, `cg_app_blueprint.py`, `tests.py`)
- ChunkedGraph initialization supports an optional `logger` argument
  - If not specified, it will create a `{project_id}/{instance_id}/{table_id}` logger and a default `StreamHandler`
- `cg_app` creates a `ChunkedGraph` connection with its own `StreamHandler` + JSON formatting, which will be properly consumed by fluentd (see https://github.com/seung-lab/AnnotationFrameworkDeployment/pull/4)

Note:
- Had to disable `verbose` for `multiprocess_func` calls in `chunkedgraph_comp.py` as that one contains hardcoded print statements.