### PR TITLE
performance(get_subgraph)

### DIFF
--- a/pychunkedgraph/backend/chunkedgraph_utils.py
+++ b/pychunkedgraph/backend/chunkedgraph_utils.py
@@ -215,7 +215,7 @@ def partial_row_data_to_column_dict(partial_row_data: bigtable.row_data.PartialR
         -> Dict[column_keys._Column, bigtable.row_data.PartialRowData]:
     new_column_dict = {}
 
-    for family_id, column_dict in partial_row_data.cells.items():
+    for family_id, column_dict in partial_row_data._cells.items():
         for column_key, column_values in column_dict.items():
             column = column_keys.from_key(family_id, column_key)
             new_column_dict[column] = column_values

--- a/pychunkedgraph/tests/test.py
+++ b/pychunkedgraph/tests/test.py
@@ -830,6 +830,25 @@ class TestGraphSimpleQueries:
         # with pytest.raises(IndexError):
         #     cgraph.get_parent(to_label(cgraph, 5, 0, 0, 0, 1), get_only_relevant_parent=True, time_stamp=None)
 
+        children2_separate = cgraph.get_children([to_label(cgraph, 2, 0, 0, 0, 1),
+                                                  to_label(cgraph, 2, 1, 0, 0, 1),
+                                                  to_label(cgraph, 2, 2, 0, 0, 1)])
+        assert len(children2_separate) == 3
+        assert to_label(cgraph, 2, 0, 0, 0, 1) in children2_separate and \
+               np.all(np.isin(children2_separate[to_label(cgraph, 2, 0, 0, 0, 1)], children20001))
+        assert to_label(cgraph, 2, 1, 0, 0, 1) in children2_separate and \
+               np.all(np.isin(children2_separate[to_label(cgraph, 2, 1, 0, 0, 1)], children21001))
+        assert to_label(cgraph, 2, 2, 0, 0, 1) in children2_separate and \
+               np.all(np.isin(children2_separate[to_label(cgraph, 2, 2, 0, 0, 1)], children22001))
+
+        children2_combined = cgraph.get_children([to_label(cgraph, 2, 0, 0, 0, 1),
+                                                  to_label(cgraph, 2, 1, 0, 0, 1),
+                                                  to_label(cgraph, 2, 2, 0, 0, 1)], flatten=True)
+        assert len(children2_combined) == 4 and \
+                np.all(np.isin(children20001, children2_combined)) and \
+                np.all(np.isin(children21001, children2_combined)) and \
+                np.all(np.isin(children22001, children2_combined))
+
     @pytest.mark.timeout(30)
     def test_get_root(self, gen_graph_simplequerytest):
         cgraph = gen_graph_simplequerytest


### PR DESCRIPTION
* `get_children` supports multiple nodes as input
* `_execute_read` takes care of splitting requests and uses Bigtables retry logic
* speedup for `get_subgraph_nodes`
* speedup for `get_subgraph_chunk`
