### PR TITLE
Store extended precomputed-style info in bigtable

### DIFF
--- a/pychunkedgraph/app/cg_app_blueprint.py
+++ b/pychunkedgraph/app/cg_app_blueprint.py
@@ -129,7 +129,7 @@ def sleep_me(sleep):
 @bp.route('/1.0/<table_id>/info', methods=['GET'])
 def handle_info(table_id):
     cg = app_utils.get_cg(table_id)
-    return jsonify(cg.cv.info)
+    return jsonify(cg.dataset_info)
 
 
 ### GET ROOT -------------------------------------------------------------------

--- a/pychunkedgraph/backend/utils/column_keys.py
+++ b/pychunkedgraph/backend/utils/column_keys.py
@@ -134,6 +134,11 @@ class Hierarchy:
 
 
 class GraphSettings:
+    DatasetInfo = _Column(
+        key=b'dataset_info',
+        family_id='0',
+        serializer=serializers.JSON())
+
     ChunkSize = _Column(
         key=b'chunk_size',
         family_id='0',

--- a/pychunkedgraph/backend/utils/serializers.py
+++ b/pychunkedgraph/backend/utils/serializers.py
@@ -1,4 +1,5 @@
 from typing import Any, Iterable
+import json
 import numpy as np
 
 
@@ -51,6 +52,15 @@ class String(_Serializer):
         super().__init__(
             serializer=lambda x: x.encode(encoding),
             deserializer=lambda x: x.decode(),
+            basetype=str
+        )
+
+
+class JSON(_Serializer):
+    def __init__(self):
+        super().__init__(
+            serializer=lambda x: json.dumps(x).encode("utf-8"),
+            deserializer=lambda x: json.loads(x.decode()),
             basetype=str
         )
 

--- a/pychunkedgraph/meshing/meshgen_utils.py
+++ b/pychunkedgraph/meshing/meshgen_utils.py
@@ -41,7 +41,7 @@ def get_mesh_name(cg, node_id: np.uint64, mip: int) -> str:
 
 @lru_cache(maxsize=None)
 def get_segmentation_info(cg) -> dict:
-    return CloudVolume(cg._cv_path).info
+    return cg.dataset_info
 
 
 def get_mesh_block_shape(cg, graphlayer: int,
@@ -100,7 +100,7 @@ def get_highest_child_nodes_with_meshes(cg,
 
     if verify_existence:
         valid_seg_ids = []
-        with Storage("%s/%s" % (cg.cv.layer_cloudpath, cg.cv.info["mesh"])) as stor:
+        with Storage(cg.cv_mesh_path) as stor:
             while len(candidates) > 0:
                 filenames = [get_mesh_name(cg, c, MESH_MIP) for c in candidates]
 

--- a/pychunkedgraph/tests/test.py
+++ b/pychunkedgraph/tests/test.py
@@ -91,11 +91,15 @@ def lock_expired_timedelta_override(request):
 def gen_graph(request):
     def _cgraph(request, fan_out=2, n_layers=10):
         # setup Chunked Graph
+        dataset_info = {
+            "data_dir": ""
+        }
+
         graph = chunkedgraph.ChunkedGraph(
             request.function.__name__,
             project_id='IGNORE_ENVIRONMENT_PROJECT',
             credentials=credentials.AnonymousCredentials(),
-            instance_id="emulated_instance", cv_path="",
+            instance_id="emulated_instance", dataset_info=dataset_info,
             chunk_size=np.array([512, 512, 64], dtype=np.uint64),
             is_new=True, fan_out=np.uint64(fan_out),
             n_layers=np.uint64(n_layers))


### PR DESCRIPTION
Moved minimal required precomputed+graph information from the `info` object in CloudStorage to Bigtable. (Only `pinky100_sv16`, so far)
"minimal required" because we could/should also move the other graph-specific information (n_layer, fanout, chunk_size, etc.) into this info file to have everything in one location - but it's not urgent.

The Bigtable info file for `pinky100_sv16` now contains a field `data_dir` which is required for https://github.com/seung-lab/neuroglancer/pull/238