### PR TITLE
adding a bounding box option to meshing endpoint

### DIFF
--- a/pychunkedgraph/app/meshing_app_blueprint.py
+++ b/pychunkedgraph/app/meshing_app_blueprint.py
@@ -106,6 +106,13 @@ def handle_get_manifest(table_id, node_id):
     else:
         start_layer = None
 
+    if "bounds" in request.args:
+        bounds = request.args["bounds"]
+        bounding_box = np.array([b.split("-") for b in bounds.split("_")],
+                                dtype=np.int).T
+    else:
+        bounding_box = None
+        
     verify = request.args.get('verify', False)
     verify = verify in ['True', 'true', '1', True]
 

--- a/pychunkedgraph/app/meshing_app_blueprint.py
+++ b/pychunkedgraph/app/meshing_app_blueprint.py
@@ -112,7 +112,7 @@ def handle_get_manifest(table_id, node_id):
                                 dtype=np.int).T
     else:
         bounding_box = None
-        
+
     verify = request.args.get('verify', False)
     verify = verify in ['True', 'true', '1', True]
 
@@ -122,6 +122,7 @@ def handle_get_manifest(table_id, node_id):
     cg = app_utils.get_cg(table_id)
     seg_ids = meshgen_utils.get_highest_child_nodes_with_meshes(
         cg, np.uint64(node_id), stop_layer=2, start_layer=start_layer,
+        bounding_box=bounding_box,
         verify_existence=verify)
 
     filenames = [meshgen_utils.get_mesh_name(cg, s, MESH_MIP) for s in seg_ids]

--- a/pychunkedgraph/meshing/meshgen_utils.py
+++ b/pychunkedgraph/meshing/meshgen_utils.py
@@ -88,7 +88,8 @@ def get_highest_child_nodes_with_meshes(cg,
                                         node_id: np.uint64,
                                         stop_layer=1,
                                         start_layer=None,
-                                        verify_existence=False):
+                                        verify_existence=False,
+                                        bounding_box=None):
     if start_layer is None:
         start_layer = cg.n_layers
 
@@ -102,7 +103,10 @@ def get_highest_child_nodes_with_meshes(cg,
         candidates = [highest_node]
     else:
         candidates = cg.get_subgraph_nodes(
-            highest_node, return_layers=[HIGHEST_MESH_LAYER])
+            highest_node,
+            bounding_box=bounding_box,
+            bb_is_coordinate=True,
+            return_layers=[HIGHEST_MESH_LAYER])
 
     if verify_existence:
         valid_node_ids = []


### PR DESCRIPTION
this adds an option to the meshing endpoint to only get meshes of an object within a certain spatial bounding box, this will speed up use cases of synapse meshes analysis to only need to download the fragments near the synapse.