### PR TITLE
Raise exception when mincut separates sources or sinks

### DIFF
--- a/pychunkedgraph/backend/cutting.py
+++ b/pychunkedgraph/backend/cutting.py
@@ -15,7 +15,7 @@ from pychunkedgraph.backend import flatgraph_utils
 from pychunkedgraph.backend import chunkedgraph_exceptions as cg_exceptions
 
 float_max = np.finfo(np.float32).max
-
+DEBUG_MODE = False
 
 def merge_cross_chunk_edges(edges: Iterable[Sequence[np.uint64]],
                             affs: Sequence[np.uint64],
@@ -252,6 +252,7 @@ def mincut_nx(edges: Iterable[Sequence[np.uint64]], affs: Sequence[np.uint64],
     return remapped_cutset[cutset_mask]
 
 
+# TODO: Refactor/break up this long function into several functions
 def mincut_graph_tool(edges: Iterable[Sequence[np.uint64]],
                       affs: Sequence[np.uint64],
                       sources: Sequence[np.uint64],
@@ -310,6 +311,13 @@ def mincut_graph_tool(edges: Iterable[Sequence[np.uint64]],
     weighted_graph, cap, gt_edges, unique_ids = \
         flatgraph_utils.build_gt_graph(comb_edges, comb_affs,
                                        make_directed=True)
+
+    # Create an edge property to remove edges later (will be used to test whether split valid)
+    is_fake_edge = np.concatenate(
+        [[False] * len(affs), [True] * (len(sink_edges) + len(source_edges))]
+    )
+    remove_edges_later = np.concatenate([is_fake_edge, is_fake_edge])
+    edges_to_remove = weighted_graph.new_edge_property("bool", vals=remove_edges_later)
 
     sink_graph_ids = np.where(np.in1d(unique_ids, sinks))[0]
     source_graph_ids = np.where(np.in1d(unique_ids, sources))[0]
@@ -383,23 +391,52 @@ def mincut_graph_tool(edges: Iterable[Sequence[np.uint64]],
 
     time_start = time.time()
 
-    # Make sure we did not do something wrong: Check if sinks and sources are
-    # among each other and not in different sets
-    for i_cc in np.unique(part.a):
-        # Make sure to read real ids and not graph ids
-        cc_list = unique_ids[np.array(np.where(part.a == i_cc)[0],
-                                      dtype=np.int)]
+    if DEBUG_MODE:
+        # These assertions should not fail. If they do, 
+        # then something went wrong with the graph_tool mincut computation
+        for i_cc in np.unique(part.a):
+            # Make sure to read real ids and not graph ids
+            cc_list = unique_ids[np.array(np.where(part.a == i_cc)[0],
+                                        dtype=np.int)]
 
-        # if logger is not None:
-        #     logger.debug("CC size = %d" % len(cc_list))
+            if np.any(np.in1d(sources, cc_list)):
+                assert np.all(np.in1d(sources, cc_list))
+                assert ~np.any(np.in1d(sinks, cc_list))
 
-        if np.any(np.in1d(sources, cc_list)):
-            assert np.all(np.in1d(sources, cc_list))
-            assert ~np.any(np.in1d(sinks, cc_list))
+            if np.any(np.in1d(sinks, cc_list)):
+                assert np.all(np.in1d(sinks, cc_list))
+                assert ~np.any(np.in1d(sources, cc_list))
 
-        if np.any(np.in1d(sinks, cc_list)):
-            assert np.all(np.in1d(sinks, cc_list))
-            assert ~np.any(np.in1d(sources, cc_list))
+    weighted_graph.clear_filters()
+
+    for cut_edge in cut_edge_set:
+        # May be more than one edge from vertex cut_edge[0] to vertex cut_edge[1], add them all
+        parallel_edges = weighted_graph.edge(cut_edge[0], cut_edge[1], all_edges=True)
+        for edge_to_remove in parallel_edges:
+            edges_to_remove[edge_to_remove] = True
+
+    weighted_graph.set_filters(edges_to_remove, removed, True, True)
+
+    ccs_test_post_cut = flatgraph_utils.connected_components(weighted_graph)
+
+    # Make sure sinks and sources are among each other and not in different sets
+    # after removing the cut edges and the fake infinity edges
+    try:
+        for cc in ccs_test_post_cut:
+            if np.any(np.in1d(source_graph_ids, cc)):
+                assert np.all(np.in1d(source_graph_ids, cc))
+                assert ~np.any(np.in1d(sink_graph_ids, cc))
+
+            if np.any(np.in1d(sink_graph_ids, cc)):
+                assert np.all(np.in1d(sink_graph_ids, cc))
+                assert ~np.any(np.in1d(source_graph_ids, cc))
+    except AssertionError:
+        raise cg_exceptions.PreconditionError(
+                "Failed to find a cut that separated the sources from the sinks. "
+                "Please try another cut that partitions the sets cleanly if possible. "
+                "If there is a clear path between all the supervoxels in each set, "
+                "that helps the mincut algorithm."
+            )
 
     dt = time.time() - time_start
     if logger is not None:


### PR DESCRIPTION
Check if mincut operation separates sources or sinks, if it does,
do not perform it and return a useful error to the user.
Also added associated unit test.