### PR TITLE
Split preview, and refactor graph-tool mincut

### DIFF
--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -192,3 +192,11 @@ def last_edit(table_id, root_id):
     latest_timestamp = common.last_edit(table_id, root_id)
     resp = {"iso": latest_timestamp.isoformat(delimiter)}
     return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
+
+
+@bp.route('/table/<table_id>/graph/split_preview', methods=["POST"])
+@auth_requires_permission("view")
+def handle_split_preview(table_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
+    split_preview = common.handle_split_preview(table_id)
+    return jsonify_with_kwargs(split_preview, int64_as_str=int64_as_str)

--- a/pychunkedgraph/backend/chunkedgraph.py
+++ b/pychunkedgraph/backend/chunkedgraph.py
@@ -3589,7 +3589,8 @@ class ChunkedGraph(object):
                       sink_ids: Sequence[np.uint64],
                       source_coords: Sequence[Sequence[int]],
                       sink_coords: Sequence[Sequence[int]],
-                      bb_offset: Tuple[int, int, int] = (120, 120, 12)):
+                      bb_offset: Tuple[int, int, int] = (120, 120, 12),
+                      split_preview: bool = False):
 
 
         time_start = time.time()
@@ -3649,7 +3650,7 @@ class ChunkedGraph(object):
             )
 
         # Compute mincut
-        atomic_edges = cutting.mincut(edges, affs, source_ids, sink_ids)
+        atomic_edges = cutting.mincut(edges, affs, source_ids, sink_ids, split_preview=split_preview)
 
         self.logger.debug(f"Mincut: {(time.time() - time_start) * 1000:.3f}ms")
 

--- a/pychunkedgraph/backend/cutting.py
+++ b/pychunkedgraph/backend/cutting.py
@@ -1,10 +1,8 @@
 import collections
+import fastremap
 import numpy as np
-import networkx as nx
 import itertools
 import logging
-from networkx.algorithms.flow import shortest_augmenting_path, edmonds_karp, preflow_push
-from networkx.algorithms.connectivity import minimum_st_edge_cut
 import time
 import graph_tool
 import graph_tool.flow
@@ -17,60 +15,10 @@ from pychunkedgraph.backend import chunkedgraph_exceptions as cg_exceptions
 float_max = np.finfo(np.float32).max
 DEBUG_MODE = False
 
-def merge_cross_chunk_edges(edges: Iterable[Sequence[np.uint64]],
-                            affs: Sequence[np.uint64],
-                            logger: Optional[logging.Logger] = None):
-    """ Merges cross chunk edges
-    :param edges: n x 2 array of uint64s
-    :param affs: float array of length n
-    :return:
-    """
-    # mask for edges that have to be merged
-    cross_chunk_edge_mask = np.isinf(affs)
 
-    # graph with edges that have to be merged
-    cross_chunk_graph = nx.Graph()
-    cross_chunk_graph.add_edges_from(edges[cross_chunk_edge_mask])
-
-    # connected components in this graph will be combined in one component
-    ccs = nx.connected_components(cross_chunk_graph)
-
-    # Build mapping
-    # For each connected component the smallest node id is chosen to be the
-    # representative.
-    remapping = {}
-    mapping_ks = []
-    mapping_vs = []
-
-    for cc in ccs:
-        nodes = np.array(list(cc))
-        rep_node = np.min(nodes)
-
-        remapping[rep_node] = nodes
-        mapping_ks.extend(nodes)
-        mapping_vs.extend([rep_node] * len(nodes))
-
-    # Initialize mapping with a each node mapping to itself, then update
-    # those edges merged to one across chunk boundaries.
-    # u_nodes = np.unique(edges)
-    # mapping = dict(zip(u_nodes, u_nodes))
-    # mapping.update(dict(zip(mapping_ks, mapping_vs)))
-    mapping = dict(zip(mapping_ks, mapping_vs))
-
-    # Vectorize remapping
-    mapping_vec = np.vectorize(lambda a : mapping[a] if a in mapping else a)
-    remapped_edges = mapping_vec(edges)
-
-    # Remove cross chunk edges
-    remapped_edges = remapped_edges[~cross_chunk_edge_mask]
-    remapped_affs = affs[~cross_chunk_edge_mask]
-
-    return remapped_edges, remapped_affs, mapping, remapping
-
-
-def merge_cross_chunk_edges_graph_tool(edges: Iterable[Sequence[np.uint64]],
-                                       affs: Sequence[np.uint64],
-                                       logger: Optional[logging.Logger] = None):
+def merge_cross_chunk_edges_graph_tool(
+    edges: Iterable[Sequence[np.uint64]], affs: Sequence[np.uint64]
+):
     """ Merges cross chunk edges
     :param edges: n x 2 array of uint64s
     :param affs: float array of length n
@@ -82,7 +30,8 @@ def merge_cross_chunk_edges_graph_tool(edges: Iterable[Sequence[np.uint64]],
 
     # graph with edges that have to be merged
     graph, _, _, unique_ids = flatgraph_utils.build_gt_graph(
-        edges[cross_chunk_edge_mask], make_directed=True)
+        edges[cross_chunk_edge_mask], make_directed=True
+    )
 
     # connected components in this graph will be combined in one component
     ccs = flatgraph_utils.connected_components(graph)
@@ -104,152 +53,19 @@ def merge_cross_chunk_edges_graph_tool(edges: Iterable[Sequence[np.uint64]],
     u_nodes = np.unique(edges)
     u_unmapped_nodes = u_nodes[~np.in1d(u_nodes, mapping)]
 
-    unmapped_mapping = np.concatenate([u_unmapped_nodes.reshape(-1, 1),
-                                       u_unmapped_nodes.reshape(-1, 1)], axis=1)
-    mapping = np.concatenate([mapping, unmapped_mapping], axis=0)
+    unmapped_mapping = np.concatenate(
+        [u_unmapped_nodes.reshape(-1, 1), u_unmapped_nodes.reshape(-1, 1)], axis=1
+    )
+    complete_mapping = np.concatenate([mapping, unmapped_mapping], axis=0)
 
-    sort_idx = np.argsort(mapping[:, 0])
-    idx = np.searchsorted(mapping[:, 0], edges, sorter=sort_idx)
-    remapped_edges = np.asarray(mapping[:, 1])[sort_idx][idx]
+    sort_idx = np.argsort(complete_mapping[:, 0])
+    idx = np.searchsorted(complete_mapping[:, 0], edges, sorter=sort_idx)
+    mapped_edges = np.asarray(complete_mapping[:, 1])[sort_idx][idx]
 
-    remapped_edges = remapped_edges[~cross_chunk_edge_mask]
-    remapped_affs = affs[~cross_chunk_edge_mask]
+    mapped_edges = mapped_edges[~cross_chunk_edge_mask]
+    mapped_affs = affs[~cross_chunk_edge_mask]
 
-    return remapped_edges, remapped_affs, mapping, remapping
-
-
-def mincut_nx(edges: Iterable[Sequence[np.uint64]], affs: Sequence[np.uint64],
-              sources: Sequence[np.uint64], sinks: Sequence[np.uint64],
-              logger: Optional[logging.Logger] = None) -> np.ndarray:
-    """ Computes the min cut on a local graph
-    :param edges: n x 2 array of uint64s
-    :param affs: float array of length n
-    :param sources: uint64
-    :param sinks: uint64
-    :return: m x 2 array of uint64s
-        edges that should be removed
-    """
-
-    time_start = time.time()
-
-    original_edges = edges.copy()
-
-    edges, affs, mapping, remapping = merge_cross_chunk_edges(edges.copy(),
-                                                              affs.copy())
-    mapping_vec = np.vectorize(lambda a: mapping[a] if a in mapping else a)
-
-    if len(edges) == 0:
-        return []
-
-    if len(mapping) > 0:
-        assert np.unique(list(mapping.keys()), return_counts=True)[1].max() == 1
-
-    remapped_sinks = mapping_vec(sinks)
-    remapped_sources = mapping_vec(sources)
-
-    sinks = remapped_sinks
-    sources = remapped_sources
-
-    sink_connections = np.array(list(itertools.product(sinks, sinks)))
-    source_connections = np.array(list(itertools.product(sources, sources)))
-
-    weighted_graph = nx.Graph()
-    weighted_graph.add_edges_from(edges)
-    weighted_graph.add_edges_from(sink_connections)
-    weighted_graph.add_edges_from(source_connections)
-
-    for i_edge, edge in enumerate(edges):
-        weighted_graph[edge[0]][edge[1]]['capacity'] = affs[i_edge]
-        weighted_graph[edge[1]][edge[0]]['capacity'] = affs[i_edge]
-
-    # Add infinity edges for multicut
-    for sink_i in sinks:
-        for sink_j in sinks:
-            weighted_graph[sink_i][sink_j]['capacity'] = float_max
-
-    for source_i in sources:
-        for source_j in sources:
-            weighted_graph[source_i][source_j]['capacity'] = float_max
-
-
-    dt = time.time() - time_start
-    if logger is not None:
-        logger.debug("Graph creation: %.2fms" % (dt * 1000))
-    time_start = time.time()
-
-    ccs = list(nx.connected_components(weighted_graph))
-
-    for cc in ccs:
-        cc_list = list(cc)
-
-        # If connected component contains no sources and/or no sinks,
-        # remove its nodes from the mincut computation
-        if not np.any(np.in1d(sources, cc_list)) or \
-                not np.any(np.in1d(sinks, cc_list)):
-            weighted_graph.remove_nodes_from(cc)
-
-    r_flow = edmonds_karp(weighted_graph, sinks[0], sources[0])
-    cutset = minimum_st_edge_cut(weighted_graph, sources[0], sinks[0],
-                                 residual=r_flow)
-
-    # cutset = nx.minimum_edge_cut(weighted_graph, sources[0], sinks[0], flow_func=edmonds_karp)
-
-    dt = time.time() - time_start
-    if logger is not None:
-        logger.debug("Mincut comp: %.2fms" % (dt * 1000))
-
-    if cutset is None:
-        return []
-
-    time_start = time.time()
-
-    edge_cut = list(list(cutset))
-
-    weighted_graph.remove_edges_from(edge_cut)
-    ccs = list(nx.connected_components(weighted_graph))
-
-    # assert len(ccs) == 2
-
-    for cc in ccs:
-        cc_list = list(cc)
-        if logger is not None:
-            logger.debug("CC size = %d" % len(cc_list))
-
-        if np.any(np.in1d(sources, cc_list)):
-            assert np.all(np.in1d(sources, cc_list))
-            assert ~np.any(np.in1d(sinks, cc_list))
-
-        if np.any(np.in1d(sinks, cc_list)):
-            assert np.all(np.in1d(sinks, cc_list))
-            assert ~np.any(np.in1d(sources, cc_list))
-
-    dt = time.time() - time_start
-    if logger is not None:
-        logger.debug("Splitting local graph: %.2fms" % (dt * 1000))
-
-    remapped_cutset = []
-    for cut in cutset:
-        if cut[0] in remapping:
-            pre_cut = remapping[cut[0]]
-        else:
-            pre_cut = [cut[0]]
-
-        if cut[1] in remapping:
-            post_cut = remapping[cut[1]]
-        else:
-            post_cut = [cut[1]]
-
-        remapped_cutset.extend(list(itertools.product(pre_cut, post_cut)))
-        remapped_cutset.extend(list(itertools.product(post_cut, pre_cut)))
-
-    remapped_cutset = np.array(remapped_cutset, dtype=np.uint64)
-
-    remapped_cutset_flattened_view = remapped_cutset.view(dtype='u8,u8')
-    edges_flattened_view = original_edges.view(dtype='u8,u8')
-
-    cutset_mask = np.in1d(remapped_cutset_flattened_view, edges_flattened_view)
-
-    return remapped_cutset[cutset_mask]
+    return mapped_edges, mapped_affs, mapping, complete_mapping, remapping
 
 
 class LocalMincutGraph:
@@ -260,15 +76,58 @@ class LocalMincutGraph:
     """
 
     def __init__(
-        self, edges, affs, sources, sinks, gt_to_sv_mapping, split_preview=False, logger=None
+        self, cg_edges, cg_affs, cg_sources, cg_sinks, split_preview=False, logger=None
     ):
-        self.sources = sources
-        self.sinks = sinks
+        self.cg_edges = cg_edges
         self.split_preview = split_preview
-        self.gt_to_sv_mapping = gt_to_sv_mapping
+        self.logger = logger
+        time_start = time.time()
 
-        self.source_edges = list(itertools.product(sources, sources))
-        self.sink_edges = list(itertools.product(sinks, sinks))
+        # Stitch supervoxels across chunk boundaries and represent those that are
+        # connected with a cross chunk edge with a single id. This may cause id
+        # changes among sinks and sources that need to be taken care of.
+        mapped_edges, mapped_affs, cross_chunk_edge_mapping, complete_mapping, self.cross_chunk_edge_remapping = merge_cross_chunk_edges_graph_tool(
+            cg_edges, cg_affs
+        )
+
+        dt = time.time() - time_start
+        if logger is not None:
+            logger.debug("Cross edge merging: %.2fms" % (dt * 1000))
+        time_start = time.time()
+
+        if len(mapped_edges) == 0:
+            raise cg_exceptions.PostconditionError(
+                f"Local graph somehow only contains cross chunk edges"
+            )
+
+        if len(cross_chunk_edge_mapping) > 0:
+            assert (
+                np.unique(cross_chunk_edge_mapping[:, 0], return_counts=True)[1].max()
+                == 1
+            )
+
+        # Map cg sources and sinks with the cross chunk edge mapping
+        self.sources = fastremap.remap_from_array_kv(
+            np.array(cg_sources), complete_mapping[:, 0], complete_mapping[:, 1]
+        )
+        self.sinks = fastremap.remap_from_array_kv(
+            np.array(cg_sinks), complete_mapping[:, 0], complete_mapping[:, 1]
+        )
+
+        self._build_gt_graph(mapped_edges, mapped_affs)
+
+        dt = time.time() - time_start
+        if logger is not None:
+            logger.debug("Graph creation: %.2fms" % (dt * 1000))
+
+        self._create_fake_edge_property(mapped_affs)
+
+    def _build_gt_graph(self, edges, affs):
+        """
+        Create the graph that will be used to compute the mincut.
+        """
+        self.source_edges = list(itertools.product(self.sources, self.sources))
+        self.sink_edges = list(itertools.product(self.sinks, self.sinks))
 
         # Assemble edges: Edges after remapping combined with fake infinite affinity
         # edges between sinks and sources
@@ -280,23 +139,22 @@ class LocalMincutGraph:
         # To make things easier for everyone involved, we map the ids to
         # [0, ..., len(unique_ids) - 1]
         # Generate weighted graph with graph_tool
-        self.weighted_graph, self.capacities, self.gt_edges, self.unique_ids = flatgraph_utils.build_gt_graph(
+        self.weighted_graph, self.capacities, self.gt_edges, self.unique_supervoxel_ids = flatgraph_utils.build_gt_graph(
             comb_edges, comb_affs, make_directed=True
         )
 
-        self.source_graph_ids = np.where(np.in1d(self.unique_ids, sources))[0]
-        self.sink_graph_ids = np.where(np.in1d(self.unique_ids, sinks))[0]
+        self.source_graph_ids = np.where(
+            np.in1d(self.unique_supervoxel_ids, self.sources)
+        )[0]
+        self.sink_graph_ids = np.where(np.in1d(self.unique_supervoxel_ids, self.sinks))[
+            0
+        ]
 
-        self.logger = logger
+        if self.logger is not None:
+            self.logger.debug(f"{self.sinks}, {self.sink_graph_ids}")
+            self.logger.debug(f"{self.sources}, {self.source_graph_ids}")
 
-        if logger is not None:
-            logger.debug(f"{sinks}, {self.sink_graph_ids}")
-            logger.debug(f"{sources}, {self.source_graph_ids}")
-
-        self._create_fake_edge_property(affs)
-
-
-    def compute_mincut(self, cg_edges):
+    def compute_mincut(self):
         """
         Compute mincut and return the supervoxel cut edge set
         """
@@ -328,23 +186,24 @@ class LocalMincutGraph:
             return self._get_split_preview_connected_components(cut_edge_set)
 
         self._sink_and_source_connectivity_sanity_check(cut_edge_set)
-        return self._remap_cut_edge_set(cut_edge_set, cg_edges)
+        return self._remap_cut_edge_set(cut_edge_set)
 
-
-    def _remap_cut_edge_set(self, cut_edge_set, cg_edges):
+    def _remap_cut_edge_set(self, cut_edge_set):
         """
         Remap the cut edge set from graph ids to supervoxel ids and return it
         """
         remapped_cutset = []
-        for s, t in flatgraph_utils.remap_ids_from_graph(cut_edge_set, self.unique_ids):
+        for s, t in flatgraph_utils.remap_ids_from_graph(
+            cut_edge_set, self.unique_supervoxel_ids
+        ):
 
-            if s in self.gt_to_sv_mapping:
-                s = self.gt_to_sv_mapping[s]
+            if s in self.cross_chunk_edge_remapping:
+                s = self.cross_chunk_edge_remapping[s]
             else:
                 s = [s]
 
-            if t in self.gt_to_sv_mapping:
-                t = self.gt_to_sv_mapping[t]
+            if t in self.cross_chunk_edge_remapping:
+                t = self.cross_chunk_edge_remapping[t]
             else:
                 t = [t]
 
@@ -354,12 +213,11 @@ class LocalMincutGraph:
         remapped_cutset = np.array(remapped_cutset, dtype=np.uint64)
 
         remapped_cutset_flattened_view = remapped_cutset.view(dtype="u8,u8")
-        edges_flattened_view = cg_edges.view(dtype="u8,u8")
+        edges_flattened_view = self.cg_edges.view(dtype="u8,u8")
 
         cutset_mask = np.in1d(remapped_cutset_flattened_view, edges_flattened_view)
 
         return remapped_cutset[cutset_mask]
-
 
     def _get_split_preview_connected_components(self, cut_edge_set):
         """
@@ -387,8 +245,12 @@ class LocalMincutGraph:
                 max_sinks = num_sinks
                 max_sink_index = i
             i += 1
-        supervoxel_ccs[0] = self.unique_ids[ccs_test_post_cut[max_source_index]]
-        supervoxel_ccs[1] = self.unique_ids[ccs_test_post_cut[max_sink_index]]
+        supervoxel_ccs[0] = self.unique_supervoxel_ids[
+            ccs_test_post_cut[max_source_index]
+        ]
+        supervoxel_ccs[1] = self.unique_supervoxel_ids[
+            ccs_test_post_cut[max_sink_index]
+        ]
         i = 0
         j = 2
         for cc in ccs_test_post_cut:
@@ -397,7 +259,6 @@ class LocalMincutGraph:
                 j += 1
             i += 1
         return (supervoxel_ccs, illegal_split)
-
 
     def _create_fake_edge_property(self, affs):
         """
@@ -414,7 +275,6 @@ class LocalMincutGraph:
         self.edges_to_remove = self.weighted_graph.new_edge_property(
             "bool", vals=remove_edges_later
         )
-
 
     def _filter_graph_connected_components(self):
         """
@@ -457,7 +317,6 @@ class LocalMincutGraph:
                 "Please try a different set of vertices to perform the mincut."
             )
 
-
     def _gt_mincut_sanity_check(self, partition):
         """
         After the mincut has been computed, assert that: the sources are within
@@ -467,7 +326,7 @@ class LocalMincutGraph:
         """
         for i_cc in np.unique(partition.a):
             # Make sure to read real ids and not graph ids
-            cc_list = self.unique_ids[
+            cc_list = self.unique_supervoxel_ids[
                 np.array(np.where(partition.a == i_cc)[0], dtype=np.int)
             ]
 
@@ -478,7 +337,6 @@ class LocalMincutGraph:
             if np.any(np.in1d(self.sinks, cc_list)):
                 assert np.all(np.in1d(self.sinks, cc_list))
                 assert ~np.any(np.in1d(self.sources, cc_list))
-
 
     def _sink_and_source_connectivity_sanity_check(self, cut_edge_set):
         """
@@ -529,12 +387,14 @@ class LocalMincutGraph:
         return ccs_test_post_cut, illegal_split
 
 
-def mincut_graph_tool(cg_edges: Iterable[Sequence[np.uint64]],
-                      cg_affs: Sequence[np.uint64],
-                      cg_sources: Sequence[np.uint64],
-                      cg_sinks: Sequence[np.uint64],
-                      logger: Optional[logging.Logger] = None,
-                      split_preview: bool = False) -> np.ndarray:
+def mincut(
+    edges: Iterable[Sequence[np.uint64]],
+    affs: Sequence[np.uint64],
+    sources: Sequence[np.uint64],
+    sinks: Sequence[np.uint64],
+    logger: Optional[logging.Logger] = None,
+    split_preview: bool = False,
+) -> np.ndarray:
     """ Computes the min cut on a local graph
     :param edges: n x 2 array of uint64s
     :param affs: float array of length n
@@ -543,57 +403,13 @@ def mincut_graph_tool(cg_edges: Iterable[Sequence[np.uint64]],
     :return: m x 2 array of uint64s
         edges that should be removed
     """
-    time_start = time.time()
 
-    # Stitch supervoxels across chunk boundaries and represent those that are
-    # connected with a cross chunk edge with a single id. This may cause id
-    # changes among sinks and sources that need to be taken care of.
-    edges, affs, sv_to_gt_mapping, gt_to_sv_mapping = merge_cross_chunk_edges(cg_edges.copy(),cg_affs.copy())
+    local_mincut_graph = LocalMincutGraph(
+        edges, affs, sources, sinks, split_preview, logger
+    )
 
-    dt = time.time() - time_start
-    if logger is not None:
-        logger.debug("Cross edge merging: %.2fms" % (dt * 1000))
-    time_start = time.time()
-
-    mapping_vec = np.vectorize(lambda a: sv_to_gt_mapping[a] if a in sv_to_gt_mapping else a)
-
-    if len(edges) == 0:
-        return []
-
-    if len(sv_to_gt_mapping) > 0:
-        assert np.unique(list(sv_to_gt_mapping.keys()), return_counts=True)[1].max() == 1
-
-    sources = mapping_vec(cg_sources)
-    sinks = mapping_vec(cg_sinks)
-
-    local_mincut_graph = LocalMincutGraph(edges, affs, sources, sinks, gt_to_sv_mapping, split_preview, logger)
-
-    dt = time.time() - time_start
-    if logger is not None:
-        logger.debug("Graph creation: %.2fms" % (dt * 1000))
-
-    mincut = local_mincut_graph.compute_mincut(cg_edges)
+    mincut = local_mincut_graph.compute_mincut()
     if len(mincut) == 0:
         return []
 
     return mincut
-
-
-def mincut(edges: Iterable[Sequence[np.uint64]],
-           affs: Sequence[np.uint64],
-           sources: Sequence[np.uint64],
-           sinks: Sequence[np.uint64],
-           logger: Optional[logging.Logger] = None,
-           split_preview: bool = False) -> np.ndarray:
-    """ Computes the min cut on a local graph
-    :param edges: n x 2 array of uint64s
-    :param affs: float array of length n
-    :param sources: uint64
-    :param sinks: uint64
-    :return: m x 2 array of uint64s
-        edges that should be removed
-    """
-
-    return mincut_graph_tool(cg_edges=edges, cg_affs=affs, cg_sources=sources,
-                             cg_sinks=sinks, logger=logger, split_preview=split_preview)
-

--- a/pychunkedgraph/backend/cutting.py
+++ b/pychunkedgraph/backend/cutting.py
@@ -29,7 +29,7 @@ def merge_cross_chunk_edges_graph_tool(
     cross_chunk_edge_mask = np.isinf(affs)
 
     # graph with edges that have to be merged
-    graph, _, _, unique_ids = flatgraph_utils.build_gt_graph(
+    graph, _, _, unique_supervoxel_ids = flatgraph_utils.build_gt_graph(
         edges[cross_chunk_edge_mask], make_directed=True
     )
 
@@ -40,7 +40,7 @@ def merge_cross_chunk_edges_graph_tool(
     mapping = np.array([], dtype=np.uint64).reshape(-1, 2)
 
     for cc in ccs:
-        nodes = unique_ids[cc]
+        nodes = unique_supervoxel_ids[cc]
         rep_node = np.min(nodes)
 
         remapping[rep_node] = nodes
@@ -137,7 +137,7 @@ class LocalMincutGraph:
         )
 
         # To make things easier for everyone involved, we map the ids to
-        # [0, ..., len(unique_ids) - 1]
+        # [0, ..., len(unique_supervoxel_ids) - 1]
         # Generate weighted graph with graph_tool
         self.weighted_graph, self.capacities, self.gt_edges, self.unique_supervoxel_ids = flatgraph_utils.build_gt_graph(
             comb_edges, comb_affs, make_directed=True
@@ -255,7 +255,7 @@ class LocalMincutGraph:
         j = 2
         for cc in ccs_test_post_cut:
             if i != max_source_index and i != max_sink_index:
-                supervoxel_ccs[j] = self.unique_ids[cc]
+                supervoxel_ccs[j] = self.unique_supervoxel_ids[cc]
                 j += 1
             i += 1
         return (supervoxel_ccs, illegal_split)

--- a/pychunkedgraph/backend/cutting.py
+++ b/pychunkedgraph/backend/cutting.py
@@ -70,9 +70,9 @@ def merge_cross_chunk_edges_graph_tool(
 
 class LocalMincutGraph:
     """
-    Helper class for mincut computation. Used by the mincut_graph_tool function to: 
-    (1) set up a local graph-tool graph, (2) compute a mincut, (3) ensure required conditions hold, 
-    and (4) return the ChunkedGraph edges to be removed. 
+    Helper class for mincut computation. Used by the mincut_graph_tool function to:
+    (1) set up a local graph-tool graph, (2) compute a mincut, (3) ensure required conditions hold,
+    and (4) return the ChunkedGraph edges to be removed.
     """
 
     def __init__(
@@ -278,7 +278,7 @@ class LocalMincutGraph:
 
     def _filter_graph_connected_components(self):
         """
-        Filter out connected components in the graph 
+        Filter out connected components in the graph
         that are not involved in the local mincut
         """
         ccs = flatgraph_utils.connected_components(self.weighted_graph)
@@ -321,7 +321,7 @@ class LocalMincutGraph:
         """
         After the mincut has been computed, assert that: the sources are within
         one connected component, and the sinks are within another separate one.
-        These assertions should not fail. If they do, 
+        These assertions should not fail. If they do,
         then something went wrong with the graph_tool mincut computation
         """
         for i_cc in np.unique(partition.a):


### PR DESCRIPTION
- Add split_preview endpoint
- Split_preview endpoint performs mincut calculation using graph-tool
- Returns connected components containing supervoxels. These are the components in the local graph that would result from removing the edges that the mincut calculation found
- There is no caching of the split. The user would have to perform a new mincut calculation to actually perform the split.
- Also refactored the graph-tool mincut from a monolithic function to a class with many modular functions