### PR TITLE
Sync Neuroglancer with API v1

### DIFF
--- a/pychunkedgraph/app/__init__.py
+++ b/pychunkedgraph/app/__init__.py
@@ -23,10 +23,18 @@ from .segmentation.generic.routes import bp as generic_api
 
 
 class CustomJsonEncoder(json.JSONEncoder):
+    def __init__(self, int64_as_str=False, **kwargs):
+        super().__init__(**kwargs)
+        self.int64_as_str = int64_as_str
+
     def default(self, obj):
         if isinstance(obj, np.ndarray):
+            if self.int64_as_str and obj.dtype.type in (np.int64, np.uint64):
+                return obj.astype(str).tolist()
             return obj.tolist()
         elif isinstance(obj, np.generic):
+            if self.int64_as_str and obj.dtype.type in (np.int64, np.uint64):
+                return obj.astype(str).item()
             return obj.item()
         elif isinstance(obj, datetime.datetime):
             return obj.__str__()

--- a/pychunkedgraph/app/__init__.py
+++ b/pychunkedgraph/app/__init__.py
@@ -19,7 +19,7 @@ from .meshing.legacy.routes import bp as meshing_api_legacy
 from .meshing.v1.routes import bp as meshing_api_v1
 from .segmentation.legacy.routes import bp as segmentation_api_legacy
 from .segmentation.v1.routes import bp as segmentation_api_v1
-from pychunkedgraph.app.segmentation.generic.routes import bp as generic_api
+from .segmentation.generic.routes import bp as generic_api
 
 
 class CustomJsonEncoder(json.JSONEncoder):

--- a/pychunkedgraph/app/app_utils.py
+++ b/pychunkedgraph/app/app_utils.py
@@ -1,55 +1,52 @@
+import logging
+import sys
+import time
+
+import numpy as np
 from flask import current_app, json
-from google.auth import credentials, default as default_creds
+from google.auth import credentials
+from google.auth import default as default_creds
 from google.cloud import bigtable, datastore
 
-import sys
-import numpy as np
-import logging
-import time
-import redis
-import functools
-
-from pychunkedgraph.logging import jsonformatter, flask_log_db
 from pychunkedgraph.backend import chunkedgraph
+from pychunkedgraph.logging import flask_log_db, jsonformatter
 
-cache = {}
+CACHE = {}
 
 
 class DoNothingCreds(credentials.Credentials):
     def refresh(self, request):
         pass
 
+
 def jsonify_with_kwargs(data, **kwargs):
-    kwargs.setdefault('separators', (",", ":"))
+    kwargs.setdefault("separators", (",", ":"))
 
     if current_app.config["JSONIFY_PRETTYPRINT_REGULAR"] or current_app.debug:
-        kwargs['indent'] = 2
-        kwargs['separators'] = (", ", ": ")
+        kwargs["indent"] = 2
+        kwargs["separators"] = (", ", ": ")
 
     return current_app.response_class(
-        json.dumps(data, **kwargs) + "\n",
-        mimetype=current_app.config["JSONIFY_MIMETYPE"],
+        json.dumps(data, **kwargs) + "\n", mimetype=current_app.config["JSONIFY_MIMETYPE"]
     )
 
 
 def get_bigtable_client(config):
-    project_id = config.get('project_id', 'pychunkedgraph')
+    project_id = config.get("project_id", "pychunkedgraph")
 
-    if config.get('emulate', False):
+    if config.get("emulate", False):
         credentials = DoNothingCreds()
     else:
         credentials, project_id = default_creds()
 
-    client = bigtable.Client(admin=True,
-                             project=project_id,
-                             credentials=credentials)
+    client = bigtable.Client(admin=True, project=project_id, credentials=credentials)
     return client
 
 
 def get_datastore_client(config):
-    project_id = config.get('project_id', 'pychunkedgraph')
+    project_id = config.get("project_id", "pychunkedgraph")
 
-    if config.get('emulate', False):
+    if config.get("emulate", False):
         credentials = DoNothingCreds()
     else:
         credentials, project_id = default_creds()
@@ -59,46 +56,49 @@ def get_datastore_client(config):
 
 
 def get_cg(table_id):
-    assert table_id.startswith("fly") or table_id.startswith("golden") or \
-           table_id.startswith("pinky100_rv")
+    assert (
+        table_id.startswith("fly")
+        or table_id.startswith("golden")
+        or table_id.startswith("pinky100_rv")
+    )
 
-    if table_id not in cache:
-        instance_id = current_app.config['CHUNKGRAPH_INSTANCE_ID']
+    if table_id not in CACHE:
+        instance_id = current_app.config["CHUNKGRAPH_INSTANCE_ID"]
         client = get_bigtable_client(current_app.config)
 
         # Create ChunkedGraph logging
         logger = logging.getLogger(f"{instance_id}/{table_id}")
-        logger.setLevel(current_app.config['LOGGING_LEVEL'])
+        logger.setLevel(current_app.config["LOGGING_LEVEL"])
 
         # prevent duplicate logs from Flasks(?) parent logger
         logger.propagate = False
 
         handler = logging.StreamHandler(sys.stdout)
-        handler.setLevel(current_app.config['LOGGING_LEVEL'])
+        handler.setLevel(current_app.config["LOGGING_LEVEL"])
         formatter = jsonformatter.JsonFormatter(
-            fmt=current_app.config['LOGGING_FORMAT'],
-            datefmt=current_app.config['LOGGING_DATEFORMAT'])
+            fmt=current_app.config["LOGGING_FORMAT"],
+            datefmt=current_app.config["LOGGING_DATEFORMAT"],
+        )
         formatter.converter = time.gmtime
         handler.setFormatter(formatter)
 
         logger.addHandler(handler)
 
         # Create ChunkedGraph
-        cache[table_id] = chunkedgraph.ChunkedGraph(table_id=table_id,
-                                                    instance_id=instance_id,
-                                                    client=client,
-                                                    logger=logger)
+        CACHE[table_id] = chunkedgraph.ChunkedGraph(
+            table_id=table_id, instance_id=instance_id, client=client, logger=logger
+        )
+
     current_app.table_id = table_id
-    return cache[table_id]
+    return CACHE[table_id]
 
 
 def get_log_db(table_id):
-    if 'log_db' not in cache:
+    if "log_db" not in CACHE:
         client = get_datastore_client(current_app.config)
-        cache["log_db"] = flask_log_db.FlaskLogDatabase(table_id,
-                                                        client=client)
+        CACHE["log_db"] = flask_log_db.FlaskLogDatabase(table_id, client=client)
 
-    return cache["log_db"]
+    return CACHE["log_db"]
 
 
 def toboolean(value):

--- a/pychunkedgraph/app/meshing/legacy/routes.py
+++ b/pychunkedgraph/app/meshing/legacy/routes.py
@@ -78,6 +78,6 @@ def handle_valid_frags(table_id, node_id):
 
 
 @bp.route("/<table_id>/manifest/<node_id>:0", methods=["GET"])
-# @auth_requires_permission("view")
+@auth_requires_permission("view")
 def handle_get_manifest(table_id, node_id):
     return common.handle_get_manifest(table_id, node_id)

--- a/pychunkedgraph/app/meshing/legacy/routes.py
+++ b/pychunkedgraph/app/meshing/legacy/routes.py
@@ -1,12 +1,7 @@
-import json
-
-import numpy as np
-from flask import Blueprint, Response, request
-
+from flask import Blueprint
 from middle_auth_client import auth_requires_permission
-from pychunkedgraph.app import app_utils
+
 from pychunkedgraph.app.meshing import common
-from pychunkedgraph.meshing import meshgen
 
 bp = Blueprint("pcg_meshing_v0", __name__, url_prefix="/meshing/1.0")
 
@@ -24,45 +19,6 @@ def index():
 @bp.route
 def home():
     return common.home()
-
-
-# ------------------------------------------------------------------------------
-
-
-@bp.route("/<table_id>/<node_id>/mesh_preview", methods=["POST", "GET"])
-@auth_requires_permission("edit")
-def handle_preview_meshes(table_id, node_id):
-    if len(request.data) > 0:
-        data = json.loads(request.data)
-    else:
-        data = {}
-
-    node_id = np.uint64(node_id)
-
-    cg = app_utils.get_cg(table_id)
-
-    if "seg_ids" in data:
-        seg_ids = data["seg_ids"]
-
-        chunk_id = cg.get_chunk_id(node_id)
-        supervoxel_ids = [cg.get_node_id(seg_id, chunk_id) for seg_id in seg_ids]
-    else:
-        supervoxel_ids = None
-
-    meshgen.mesh_lvl2_preview(
-        cg,
-        node_id,
-        supervoxel_ids=supervoxel_ids,
-        cv_path=None,
-        cv_mesh_dir=None,
-        mip=2,
-        simplification_factor=999999,
-        max_err=40,
-        parallel_download=1,
-        verbose=True,
-        cache_control="no-cache",
-    )
-    return Response(status=200)
 
 
 ## VALIDFRAGMENTS --------------------------------------------------------------

--- a/pychunkedgraph/app/meshing/v1/routes.py
+++ b/pychunkedgraph/app/meshing/v1/routes.py
@@ -1,6 +1,6 @@
-from flask import Blueprint, Response
-
+from flask import Blueprint
 from middle_auth_client import auth_requires_permission
+
 from pychunkedgraph.app.meshing import common
 
 bp = Blueprint("pcg_meshing_v1", __name__, url_prefix="/meshing/api/v1")
@@ -19,15 +19,6 @@ def index():
 @bp.route
 def home():
     return common.home()
-
-
-# ------------------------------------------------------------------------------
-
-
-@bp.route("/table/<table_id>/node/<node_id>/mesh_preview", methods=["POST", "GET"])
-@auth_requires_permission("edit")
-def handle_preview_meshes(table_id, node_id):  # pylint: disable=unused-argument
-    return Response(status=410)
 
 
 ## VALIDFRAGMENTS --------------------------------------------------------------

--- a/pychunkedgraph/app/segmentation/generic/routes.py
+++ b/pychunkedgraph/app/segmentation/generic/routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint
+from middle_auth_client import auth_requires_admin
 from pychunkedgraph.app.segmentation import common
 
 bp = Blueprint("pcg_generic_v1", __name__, url_prefix="/segmentation")
@@ -26,6 +27,7 @@ def home():
 
 
 @bp.route("/sleep/<int:sleep>")
+@auth_requires_admin
 def sleep_me(sleep):
     return common.sleep_me(sleep)
 

--- a/pychunkedgraph/app/segmentation/generic/routes.py
+++ b/pychunkedgraph/app/segmentation/generic/routes.py
@@ -1,5 +1,4 @@
 from flask import Blueprint
-
 from pychunkedgraph.app.segmentation import common
 
 bp = Blueprint("pcg_generic_v1", __name__, url_prefix="/segmentation")

--- a/pychunkedgraph/app/segmentation/generic/routes.py
+++ b/pychunkedgraph/app/segmentation/generic/routes.py
@@ -41,5 +41,5 @@ def handle_info(table_id):
 
 
 @bp.route("/api/versions", methods=["GET"])
-def handle_api_version():
+def handle_api_versions():
     return common.handle_api_versions()

--- a/pychunkedgraph/app/segmentation/legacy/routes.py
+++ b/pychunkedgraph/app/segmentation/legacy/routes.py
@@ -177,6 +177,7 @@ def merge_log(table_id, root_id):
 @bp.route("/<table_id>/graph/oldest_timestamp", methods=["POST", "GET"])
 @auth_requires_permission("view")
 def oldest_timestamp(table_id):
+    delimiter = request.args.get("delimiter", " ")
     earliest_timestamp = common.oldest_timestamp(table_id)
-    resp = {"iso": str(earliest_timestamp)}
+    resp = {"iso": earliest_timestamp.isoformat(delimiter)}
     return jsonify(resp)

--- a/pychunkedgraph/app/segmentation/legacy/routes.py
+++ b/pychunkedgraph/app/segmentation/legacy/routes.py
@@ -1,6 +1,10 @@
-from flask import Blueprint
-from middle_auth_client import auth_requires_permission
+import json
 
+import numpy as np
+
+from flask import Blueprint, jsonify, request
+from middle_auth_client import auth_requires_permission
+from pychunkedgraph.app import app_utils
 from pychunkedgraph.app.segmentation import common
 from pychunkedgraph.backend import chunkedgraph_exceptions as cg_exceptions
 
@@ -70,13 +74,16 @@ def handle_info(table_id):
 @bp.route("/<table_id>/graph/root", methods=["POST", "GET"])
 @auth_requires_permission("view")
 def handle_root_1(table_id):
-    return common.handle_root_1(table_id)
+    atomic_id = np.uint64(json.loads(request.data)[0])
+    root_id = common.handle_root(table_id, atomic_id)
+    return app_utils.tobinary(root_id)
 
 
 @bp.route("/<table_id>/graph/<atomic_id>/root", methods=["POST", "GET"])
 @auth_requires_permission("view")
 def handle_root_2(table_id, atomic_id):
-    return common.handle_root_2(table_id, atomic_id)
+    root_id = common.handle_root(table_id, atomic_id)
+    return app_utils.tobinary(root_id)
 
 
 ### MERGE ----------------------------------------------------------------------
@@ -85,7 +92,8 @@ def handle_root_2(table_id, atomic_id):
 @bp.route("/<table_id>/graph/merge", methods=["POST", "GET"])
 @auth_requires_permission("edit")
 def handle_merge(table_id):
-    return common.handle_merge(table_id, bin_return=True)
+    merge_result = common.handle_merge(table_id)
+    return app_utils.tobinary(merge_result.new_root_ids)
 
 
 ### SPLIT ----------------------------------------------------------------------
@@ -94,7 +102,8 @@ def handle_merge(table_id):
 @bp.route("/<table_id>/graph/split", methods=["POST", "GET"])
 @auth_requires_permission("edit")
 def handle_split(table_id):
-    return common.handle_split(table_id, bin_return=True)
+    split_result = common.handle_split(table_id)
+    return app_utils.tobinary(split_result.new_root_ids)
 
 
 ### CHILDREN -------------------------------------------------------------------
@@ -103,7 +112,8 @@ def handle_split(table_id):
 @bp.route("/<table_id>/segment/<parent_id>/children", methods=["POST", "GET"])
 @auth_requires_permission("view")
 def handle_children(table_id, parent_id):
-    return common.handle_children(table_id, parent_id)
+    children_ids = common.handle_children(table_id, parent_id)
+    return app_utils.tobinary(children_ids)
 
 
 ### LEAVES ---------------------------------------------------------------------
@@ -112,7 +122,8 @@ def handle_children(table_id, parent_id):
 @bp.route("/<table_id>/segment/<root_id>/leaves", methods=["POST", "GET"])
 @auth_requires_permission("view")
 def handle_leaves(table_id, root_id):
-    return common.handle_leaves(table_id, root_id)
+    leaf_ids = common.handle_leaves(table_id, root_id)
+    return app_utils.tobinary(leaf_ids)
 
 
 ### LEAVES FROM LEAVES ---------------------------------------------------------
@@ -121,7 +132,8 @@ def handle_leaves(table_id, root_id):
 @bp.route("/<table_id>/segment/<atomic_id>/leaves_from_leave", methods=["POST", "GET"])
 @auth_requires_permission("view")
 def handle_leaves_from_leave(table_id, atomic_id):
-    return common.handle_leaves_from_leave(table_id, atomic_id)
+    leaf_ids = common.handle_leaves_from_leave(table_id, atomic_id)
+    return app_utils.tobinary(leaf_ids)
 
 
 ### SUBGRAPH -------------------------------------------------------------------
@@ -130,7 +142,8 @@ def handle_leaves_from_leave(table_id, atomic_id):
 @bp.route("/<table_id>/segment/<root_id>/subgraph", methods=["POST", "GET"])
 @auth_requires_permission("view")
 def handle_subgraph(table_id, root_id):
-    return common.handle_subgraph(table_id, root_id)
+    subgraph_result = common.handle_subgraph(table_id, root_id)
+    return app_utils.tobinary(subgraph_result)
 
 
 ### CHANGE LOG -----------------------------------------------------------------
@@ -139,19 +152,23 @@ def handle_subgraph(table_id, root_id):
 @bp.route("/<table_id>/segment/<root_id>/change_log", methods=["POST", "GET"])
 @auth_requires_permission("view")
 def change_log(table_id, root_id):
-    return common.change_log(table_id, root_id)
+    log = common.change_log(table_id, root_id)
+    return jsonify(log)
 
 
 @bp.route("/<table_id>/segment/<root_id>/merge_log", methods=["POST", "GET"])
 @auth_requires_permission("view")
 def merge_log(table_id, root_id):
-    return common.merge_log(table_id, root_id)
+    log = common.merge_log(table_id, root_id)
+    return jsonify(log)
 
 
 @bp.route("/<table_id>/graph/oldest_timestamp", methods=["POST", "GET"])
 @auth_requires_permission("view")
 def oldest_timestamp(table_id):
-    return common.oldest_timestamp(table_id)
+    earliest_timestamp = common.oldest_timestamp(table_id)
+    resp = {"iso": str(earliest_timestamp)}
+    return jsonify(resp)
 
 
 ### CONTACT SITES --------------------------------------------------------------
@@ -160,4 +177,5 @@ def oldest_timestamp(table_id):
 @bp.route("/<table_id>/segment/<root_id>/contact_sites", methods=["POST", "GET"])
 @auth_requires_permission("view")
 def handle_contact_sites(table_id, root_id):
-    return common.handle_contact_sites(table_id, root_id)
+    contact_sites = common.handle_contact_sites(table_id, root_id)
+    return jsonify(contact_sites)

--- a/pychunkedgraph/app/segmentation/legacy/routes.py
+++ b/pychunkedgraph/app/segmentation/legacy/routes.py
@@ -3,7 +3,7 @@ import json
 import numpy as np
 
 from flask import Blueprint, jsonify, request
-from middle_auth_client import auth_requires_permission
+from middle_auth_client import auth_requires_admin, auth_requires_permission
 from pychunkedgraph.app import app_utils
 from pychunkedgraph.app.segmentation import common
 from pychunkedgraph.backend import chunkedgraph_exceptions as cg_exceptions
@@ -58,6 +58,7 @@ def api_exception(e):
 
 
 @bp.route("/sleep/<int:sleep>")
+@auth_requires_admin
 def sleep_me(sleep):
     return common.sleep_me(sleep)
 

--- a/pychunkedgraph/app/segmentation/legacy/routes.py
+++ b/pychunkedgraph/app/segmentation/legacy/routes.py
@@ -68,24 +68,6 @@ def handle_info(table_id):
     return common.handle_info(table_id)
 
 
-### GET ROOT -------------------------------------------------------------------
-
-
-@bp.route("/<table_id>/graph/root", methods=["POST", "GET"])
-@auth_requires_permission("view")
-def handle_root_1(table_id):
-    atomic_id = np.uint64(json.loads(request.data)[0])
-    root_id = common.handle_root(table_id, atomic_id)
-    return app_utils.tobinary(root_id)
-
-
-@bp.route("/<table_id>/graph/<atomic_id>/root", methods=["POST", "GET"])
-@auth_requires_permission("view")
-def handle_root_2(table_id, atomic_id):
-    root_id = common.handle_root(table_id, atomic_id)
-    return app_utils.tobinary(root_id)
-
-
 ### MERGE ----------------------------------------------------------------------
 
 
@@ -104,6 +86,24 @@ def handle_merge(table_id):
 def handle_split(table_id):
     split_result = common.handle_split(table_id)
     return app_utils.tobinary(split_result.new_root_ids)
+
+
+### GET ROOT -------------------------------------------------------------------
+
+
+@bp.route("/<table_id>/graph/root", methods=["POST", "GET"])
+@auth_requires_permission("view")
+def handle_root_1(table_id):
+    atomic_id = np.uint64(json.loads(request.data)[0])
+    root_id = common.handle_root(table_id, atomic_id)
+    return app_utils.tobinary(root_id)
+
+
+@bp.route("/<table_id>/graph/<atomic_id>/root", methods=["POST", "GET"])
+@auth_requires_permission("view")
+def handle_root_2(table_id, atomic_id):
+    root_id = common.handle_root(table_id, atomic_id)
+    return app_utils.tobinary(root_id)
 
 
 ### CHILDREN -------------------------------------------------------------------
@@ -146,6 +146,16 @@ def handle_subgraph(table_id, root_id):
     return app_utils.tobinary(subgraph_result)
 
 
+### CONTACT SITES --------------------------------------------------------------
+
+
+@bp.route("/<table_id>/segment/<root_id>/contact_sites", methods=["POST", "GET"])
+@auth_requires_permission("view")
+def handle_contact_sites(table_id, root_id):
+    contact_sites = common.handle_contact_sites(table_id, root_id)
+    return jsonify(contact_sites)
+
+
 ### CHANGE LOG -----------------------------------------------------------------
 
 
@@ -169,13 +179,3 @@ def oldest_timestamp(table_id):
     earliest_timestamp = common.oldest_timestamp(table_id)
     resp = {"iso": str(earliest_timestamp)}
     return jsonify(resp)
-
-
-### CONTACT SITES --------------------------------------------------------------
-
-
-@bp.route("/<table_id>/segment/<root_id>/contact_sites", methods=["POST", "GET"])
-@auth_requires_permission("view")
-def handle_contact_sites(table_id, root_id):
-    contact_sites = common.handle_contact_sites(table_id, root_id)
-    return jsonify(contact_sites)

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -176,14 +176,16 @@ def merge_log(table_id, root_id):
 @bp.route("/table/<table_id>/oldest_timestamp", methods=["GET"])
 @auth_requires_permission("view")
 def oldest_timestamp(table_id):
+    delimiter = request.args.get("delimiter", " ")
     earliest_timestamp = common.oldest_timestamp(table_id)
-    resp = {"iso": str(earliest_timestamp)}
+    resp = {"iso": earliest_timestamp.isoformat(delimiter)}
     return jsonify(resp)
 
 
 @bp.route("/table/<table_id>/root/<root_id>/last_edit", methods=["GET"])
 @auth_requires_permission("view")
 def last_edit(table_id, root_id):
+    delimiter = request.args.get("delimiter", " ")
     latest_timestamp = common.last_edit(table_id, root_id)
-    resp = {"iso": str(latest_timestamp)}
+    resp = {"iso": latest_timestamp.isoformat(delimiter)}
     return jsonify(resp)

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -47,16 +47,6 @@ def api_exception(e):
     return common.api_exception(e)
 
 
-### GET ROOT -------------------------------------------------------------------
-
-
-@bp.route("/table/<table_id>/sv/<atomic_id>/root", methods=["GET"])
-@auth_requires_permission("view")
-def handle_root(table_id, atomic_id):
-    root_id = common.handle_root(table_id, atomic_id)
-    return jsonify({"root_id": root_id})
-
-
 ### MERGE ----------------------------------------------------------------------
 
 
@@ -113,6 +103,16 @@ def handle_redo(table_id):
     return jsonify(resp)
 
 
+### GET ROOT -------------------------------------------------------------------
+
+
+@bp.route("/table/<table_id>/node/<node_id>/root", methods=["GET"])
+@auth_requires_permission("view")
+def handle_root(table_id, node_id):
+    root_id = common.handle_root(table_id, node_id)
+    return jsonify({"root_id": root_id})
+
+
 ### CHILDREN -------------------------------------------------------------------
 
 
@@ -146,6 +146,16 @@ def handle_subgraph(table_id, node_id):
     return jsonify(resp)
 
 
+### CONTACT SITES --------------------------------------------------------------
+
+
+@bp.route("/table/<table_id>/node/<node_id>/contact_sites", methods=["GET"])
+@auth_requires_permission("view")
+def handle_contact_sites(table_id, node_id):
+    contact_sites = common.handle_contact_sites(table_id, node_id)
+    return jsonify(contact_sites)
+
+
 ### CHANGE LOG -----------------------------------------------------------------
 
 
@@ -177,13 +187,3 @@ def last_edit(table_id, root_id):
     latest_timestamp = common.last_edit(table_id, root_id)
     resp = {"iso": str(latest_timestamp)}
     return jsonify(resp)
-
-
-### CONTACT SITES --------------------------------------------------------------
-
-
-@bp.route("/table/<table_id>/node/<node_id>/contact_sites", methods=["GET"])
-@auth_requires_permission("view")
-def handle_contact_sites(table_id, node_id):
-    contact_sites = common.handle_contact_sites(table_id, node_id)
-    return jsonify(contact_sites)

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -1,5 +1,7 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, request
 from middle_auth_client import auth_requires_permission
+
+from pychunkedgraph.app.app_utils import jsonify_with_kwargs, toboolean
 from pychunkedgraph.app.segmentation import common
 from pychunkedgraph.backend import chunkedgraph_exceptions as cg_exceptions
 
@@ -53,12 +55,10 @@ def api_exception(e):
 @bp.route("/table/<table_id>/merge", methods=["POST"])
 @auth_requires_permission("edit")
 def handle_merge(table_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     merge_result = common.handle_merge(table_id)
-    resp = {
-        "operation_id": merge_result.operation_id,
-        "new_root_ids": merge_result.new_root_ids,
-    }
-    return jsonify(resp)
+    resp = {"operation_id": merge_result.operation_id, "new_root_ids": merge_result.new_root_ids}
+    return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
 
 
 ### SPLIT ----------------------------------------------------------------------
@@ -67,12 +67,10 @@ def handle_merge(table_id):
 @bp.route("/table/<table_id>/split", methods=["POST"])
 @auth_requires_permission("edit")
 def handle_split(table_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     split_result = common.handle_split(table_id)
-    resp = {
-        "operation_id": split_result.operation_id,
-        "new_root_ids": split_result.new_root_ids,
-    }
-    return jsonify(resp)
+    resp = {"operation_id": split_result.operation_id, "new_root_ids": split_result.new_root_ids}
+    return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
 
 
 ### UNDO ----------------------------------------------------------------------
@@ -81,12 +79,10 @@ def handle_split(table_id):
 @bp.route("/table/<table_id>/undo", methods=["POST"])
 @auth_requires_permission("edit")
 def handle_undo(table_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     undo_result = common.handle_undo(table_id)
-    resp = {
-        "operation_id": undo_result.operation_id,
-        "new_root_ids": undo_result.new_root_ids,
-    }
-    return jsonify(resp)
+    resp = {"operation_id": undo_result.operation_id, "new_root_ids": undo_result.new_root_ids}
+    return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
 
 
 ### REDO ----------------------------------------------------------------------
@@ -95,12 +91,10 @@ def handle_undo(table_id):
 @bp.route("/table/<table_id>/redo", methods=["POST"])
 @auth_requires_permission("edit")
 def handle_redo(table_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     redo_result = common.handle_redo(table_id)
-    resp = {
-        "operation_id": redo_result.operation_id,
-        "new_root_ids": redo_result.new_root_ids,
-    }
-    return jsonify(resp)
+    resp = {"operation_id": redo_result.operation_id, "new_root_ids": redo_result.new_root_ids}
+    return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
 
 
 ### GET ROOT -------------------------------------------------------------------
@@ -109,8 +103,9 @@ def handle_redo(table_id):
 @bp.route("/table/<table_id>/node/<node_id>/root", methods=["GET"])
 @auth_requires_permission("view")
 def handle_root(table_id, node_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     root_id = common.handle_root(table_id, node_id)
-    return jsonify({"root_id": root_id})
+    return jsonify_with_kwargs({"root_id": root_id}, int64_as_str=int64_as_str)
 
 
 ### CHILDREN -------------------------------------------------------------------
@@ -119,9 +114,10 @@ def handle_root(table_id, node_id):
 @bp.route("/table/<table_id>/node/<node_id>/children", methods=["GET"])
 @auth_requires_permission("view")
 def handle_children(table_id, node_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     children_ids = common.handle_children(table_id, node_id)
     resp = {"children_ids": children_ids}
-    return jsonify(resp)
+    return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
 
 
 ### LEAVES ---------------------------------------------------------------------
@@ -130,9 +126,10 @@ def handle_children(table_id, node_id):
 @bp.route("/table/<table_id>/node/<node_id>/leaves", methods=["GET"])
 @auth_requires_permission("view")
 def handle_leaves(table_id, node_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     leaf_ids = common.handle_leaves(table_id, node_id)
     resp = {"leaf_ids": leaf_ids}
-    return jsonify(resp)
+    return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
 
 
 ### SUBGRAPH -------------------------------------------------------------------
@@ -141,9 +138,10 @@ def handle_leaves(table_id, node_id):
 @bp.route("/table/<table_id>/node/<node_id>/subgraph", methods=["GET"])
 @auth_requires_permission("view")
 def handle_subgraph(table_id, node_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     subgraph_result = common.handle_subgraph(table_id, node_id)
     resp = {"atomic_edges": subgraph_result}
-    return jsonify(resp)
+    return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
 
 
 ### CONTACT SITES --------------------------------------------------------------
@@ -152,8 +150,9 @@ def handle_subgraph(table_id, node_id):
 @bp.route("/table/<table_id>/node/<node_id>/contact_sites", methods=["GET"])
 @auth_requires_permission("view")
 def handle_contact_sites(table_id, node_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     contact_sites = common.handle_contact_sites(table_id, node_id)
-    return jsonify(contact_sites)
+    return jsonify_with_kwargs(contact_sites, int64_as_str=int64_as_str)
 
 
 ### CHANGE LOG -----------------------------------------------------------------
@@ -162,30 +161,34 @@ def handle_contact_sites(table_id, node_id):
 @bp.route("/table/<table_id>/root/<root_id>/change_log", methods=["GET"])
 @auth_requires_permission("view")
 def change_log(table_id, root_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     log = common.change_log(table_id, root_id)
-    return jsonify(log)
+    return jsonify_with_kwargs(log, int64_as_str=int64_as_str)
 
 
 @bp.route("/table/<table_id>/root/<root_id>/merge_log", methods=["GET"])
 @auth_requires_permission("view")
 def merge_log(table_id, root_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     log = common.merge_log(table_id, root_id)
-    return jsonify(log)
+    return jsonify_with_kwargs(log, int64_as_str=int64_as_str)
 
 
 @bp.route("/table/<table_id>/oldest_timestamp", methods=["GET"])
 @auth_requires_permission("view")
 def oldest_timestamp(table_id):
-    delimiter = request.args.get("delimiter", " ")
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
+    delimiter = request.args.get("delimiter", default=" ", type=str)
     earliest_timestamp = common.oldest_timestamp(table_id)
     resp = {"iso": earliest_timestamp.isoformat(delimiter)}
-    return jsonify(resp)
+    return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
 
 
 @bp.route("/table/<table_id>/root/<root_id>/last_edit", methods=["GET"])
 @auth_requires_permission("view")
 def last_edit(table_id, root_id):
-    delimiter = request.args.get("delimiter", " ")
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
+    delimiter = request.args.get("delimiter", default=" ", type=str)
     latest_timestamp = common.last_edit(table_id, root_id)
     resp = {"iso": latest_timestamp.isoformat(delimiter)}
-    return jsonify(resp)
+    return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -1,6 +1,5 @@
-from flask import Blueprint
+from flask import Blueprint, jsonify, request
 from middle_auth_client import auth_requires_permission
-
 from pychunkedgraph.app.segmentation import common
 from pychunkedgraph.backend import chunkedgraph_exceptions as cg_exceptions
 
@@ -54,7 +53,8 @@ def api_exception(e):
 @bp.route("/table/<table_id>/sv/<atomic_id>/root", methods=["GET"])
 @auth_requires_permission("view")
 def handle_root(table_id, atomic_id):
-    return common.handle_root_2(table_id, atomic_id)
+    root_id = common.handle_root(table_id, atomic_id)
+    return jsonify({"root_id": root_id})
 
 
 ### MERGE ----------------------------------------------------------------------
@@ -63,7 +63,12 @@ def handle_root(table_id, atomic_id):
 @bp.route("/table/<table_id>/merge", methods=["POST"])
 @auth_requires_permission("edit")
 def handle_merge(table_id):
-    return common.handle_merge(table_id)
+    merge_result = common.handle_merge(table_id)
+    resp = {
+        "operation_id": merge_result.operation_id,
+        "new_root_ids": merge_result.new_root_ids,
+    }
+    return jsonify(resp)
 
 
 ### SPLIT ----------------------------------------------------------------------
@@ -72,7 +77,12 @@ def handle_merge(table_id):
 @bp.route("/table/<table_id>/split", methods=["POST"])
 @auth_requires_permission("edit")
 def handle_split(table_id):
-    return common.handle_split(table_id)
+    split_result = common.handle_split(table_id)
+    resp = {
+        "operation_id": split_result.operation_id,
+        "new_root_ids": split_result.new_root_ids,
+    }
+    return jsonify(resp)
 
 
 ### UNDO ----------------------------------------------------------------------
@@ -81,7 +91,12 @@ def handle_split(table_id):
 @bp.route("/table/<table_id>/undo", methods=["POST"])
 @auth_requires_permission("edit")
 def handle_undo(table_id):
-    return common.handle_undo(table_id)
+    undo_result = common.handle_undo(table_id)
+    resp = {
+        "operation_id": undo_result.operation_id,
+        "new_root_ids": undo_result.new_root_ids,
+    }
+    return jsonify(resp)
 
 
 ### REDO ----------------------------------------------------------------------
@@ -90,7 +105,12 @@ def handle_undo(table_id):
 @bp.route("/table/<table_id>/redo", methods=["POST"])
 @auth_requires_permission("edit")
 def handle_redo(table_id):
-    return common.handle_redo(table_id)
+    redo_result = common.handle_redo(table_id)
+    resp = {
+        "operation_id": redo_result.operation_id,
+        "new_root_ids": redo_result.new_root_ids,
+    }
+    return jsonify(resp)
 
 
 ### CHILDREN -------------------------------------------------------------------
@@ -99,7 +119,9 @@ def handle_redo(table_id):
 @bp.route("/table/<table_id>/node/<node_id>/children", methods=["GET"])
 @auth_requires_permission("view")
 def handle_children(table_id, node_id):
-    return common.handle_children(table_id, node_id)
+    children_ids = common.handle_children(table_id, node_id)
+    resp = {"children_ids": children_ids}
+    return jsonify(resp)
 
 
 ### LEAVES ---------------------------------------------------------------------
@@ -108,7 +130,9 @@ def handle_children(table_id, node_id):
 @bp.route("/table/<table_id>/node/<node_id>/leaves", methods=["GET"])
 @auth_requires_permission("view")
 def handle_leaves(table_id, node_id):
-    return common.handle_leaves(table_id, node_id)
+    leaf_ids = common.handle_leaves(table_id, node_id)
+    resp = {"leaf_ids": leaf_ids}
+    return jsonify(resp)
 
 
 ### SUBGRAPH -------------------------------------------------------------------
@@ -117,7 +141,9 @@ def handle_leaves(table_id, node_id):
 @bp.route("/table/<table_id>/node/<node_id>/subgraph", methods=["GET"])
 @auth_requires_permission("view")
 def handle_subgraph(table_id, node_id):
-    return common.handle_subgraph(table_id, node_id)
+    subgraph_result = common.handle_subgraph(table_id, node_id)
+    resp = {"atomic_edges": subgraph_result}
+    return jsonify(resp)
 
 
 ### CHANGE LOG -----------------------------------------------------------------
@@ -126,25 +152,31 @@ def handle_subgraph(table_id, node_id):
 @bp.route("/table/<table_id>/root/<root_id>/change_log", methods=["GET"])
 @auth_requires_permission("view")
 def change_log(table_id, root_id):
-    return common.change_log(table_id, root_id)
+    log = common.change_log(table_id, root_id)
+    return jsonify(log)
 
 
 @bp.route("/table/<table_id>/root/<root_id>/merge_log", methods=["GET"])
 @auth_requires_permission("view")
 def merge_log(table_id, root_id):
-    return common.merge_log(table_id, root_id)
+    log = common.merge_log(table_id, root_id)
+    return jsonify(log)
 
 
 @bp.route("/table/<table_id>/oldest_timestamp", methods=["GET"])
 @auth_requires_permission("view")
 def oldest_timestamp(table_id):
-    return common.oldest_timestamp(table_id)
+    earliest_timestamp = common.oldest_timestamp(table_id)
+    resp = {"iso": str(earliest_timestamp)}
+    return jsonify(resp)
 
 
 @bp.route("/table/<table_id>/root/<root_id>/last_edit", methods=["GET"])
 @auth_requires_permission("view")
 def last_edit(table_id, root_id):
-    return common.last_edit(table_id, root_id)
+    latest_timestamp = common.last_edit(table_id, root_id)
+    resp = {"iso": str(latest_timestamp)}
+    return jsonify(resp)
 
 
 ### CONTACT SITES --------------------------------------------------------------
@@ -153,4 +185,5 @@ def last_edit(table_id, root_id):
 @bp.route("/table/<table_id>/node/<node_id>/contact_sites", methods=["GET"])
 @auth_requires_permission("view")
 def handle_contact_sites(table_id, node_id):
-    return common.handle_contact_sites(table_id, node_id)
+    contact_sites = common.handle_contact_sites(table_id, node_id)
+    return jsonify(contact_sites)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ zstandard
 redis
 rq
 middle-auth-client==1.2.0
-dracopy==0.0.11
+dracopy
 zmesh
 fastremap
 pyopenssl


### PR DESCRIPTION
Addresses the remaining comments in #160 

Probably most interesting: an optional query string parameter `int64_as_str` that is understood by all current v1 endpoints. If specified, the JSONEncoder will recursively inspect and convert all occurrences of `np.int64` or `np.uint64` values to `str`.