### PR TITLE
Bump DracoPy to 0.0.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ zstandard
 redis
 rq
 middle-auth-client>=0.1.6
-dracopy==0.0.11
+dracopy==0.0.13
 zmesh
 fastremap
 pyopenssl


### PR DESCRIPTION
Latest version of cmake breaks DracoPy 0.0.11 installation. 0.0.13 fixes cmake version.