### PR TITLE
Add get_roots endpoint

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -189,6 +189,32 @@ def handle_root(table_id, atomic_id):
     return root_id
 
 
+### GET ROOTS -------------------------------------------------------------------
+
+
+def handle_roots(table_id):
+    current_app.request_type = "roots"
+    current_app.table_id = table_id
+
+    node_ids = np.array(json.loads(request.data)["node_ids"], dtype=np.uint64)
+    # Convert seconds since epoch to UTC datetime
+    try:
+        timestamp = float(request.args.get("timestamp", time.time()))
+        timestamp = datetime.fromtimestamp(timestamp, UTC)
+    except (TypeError, ValueError) as e:
+        raise (
+            cg_exceptions.BadRequest(
+                "Timestamp parameter is not a valid" " unix timestamp"
+            )
+        )
+
+    # Call ChunkedGraph
+    cg = app_utils.get_cg(table_id)
+    root_ids = cg.get_roots(node_ids, time_stamp=timestamp)
+
+    return root_ids
+
+
 ### MERGE ----------------------------------------------------------------------
 
 

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -121,6 +121,17 @@ def handle_root(table_id, node_id):
     return jsonify_with_kwargs({"root_id": root_id}, int64_as_str=int64_as_str)
 
 
+### GET ROOTS -------------------------------------------------------------------
+
+
+@bp.route("/table/<table_id>/roots", methods=["POST"])
+@auth_requires_permission("view")
+def handle_roots(table_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
+    root_ids = common.handle_roots(table_id)
+    return jsonify_with_kwargs(root_ids, int64_as_str=int64_as_str)
+
+
 ### CHILDREN -------------------------------------------------------------------
 
 


### PR DESCRIPTION
For users of the ChunkedGraph who want to get the roots of several nodes at once, using `get_roots` is much more efficient than `get_root`