### PR TITLE
Weekly Tabular Changelog

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -568,10 +568,20 @@ def change_log(table_id, root_id=None):
     return segment_history.change_log()
 
 
-def tabular_change_log_recent(table_id, start_time):
+def tabular_change_log_recent(table_id):
     current_app.table_id = table_id
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
+
+    try:
+        start_time = float(request.args.get("start_time", 0))
+        start_time = datetime.fromtimestamp(start_time, UTC)
+    except (TypeError, ValueError):
+        raise (
+            cg_exceptions.BadRequest(
+                "start_time parameter is not a valid unix timestamp"
+            )
+        )
 
     # Call ChunkedGraph
     cg = app_utils.get_cg(table_id)

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -568,14 +568,14 @@ def change_log(table_id, root_id=None):
     return segment_history.change_log()
 
 
-def tabular_change_log_weekly(table_id):
+def tabular_change_log_recent(table_id, start_time):
     current_app.table_id = table_id
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
 
     # Call ChunkedGraph
     cg = app_utils.get_cg(table_id)
-    return cg_history.get_tabular_changelog_weekly(cg)
+    return cg_history.get_tabular_changelog_recent(cg, start_time)
 
 
 def tabular_change_log(table_id, root_id):

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -568,6 +568,16 @@ def change_log(table_id, root_id=None):
     return segment_history.change_log()
 
 
+def tabular_change_log_weekly(table_id):
+    current_app.table_id = table_id
+    user_id = str(g.auth_user["id"])
+    current_app.user_id = user_id
+
+    # Call ChunkedGraph
+    cg = app_utils.get_cg(table_id)
+    return cg_history.get_tabular_changelog_weekly(cg)
+
+
 def tabular_change_log(table_id, root_id):
     current_app.request_type = "tabular_changelog"
     current_app.table_id = table_id

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -586,10 +586,8 @@ def tabular_change_log_recent(table_id):
         )
 
     # Call ChunkedGraph
-    cg = app_utils.get_cg(table_id)
-    return get_tabular_changelog_recent(cg, start_time)
+    cg_instance = app_utils.get_cg(table_id)
 
-def get_tabular_changelog_recent(cg_instance, start_time):
     log_rows = cg_instance.read_log_rows(start_time=start_time)
 
     timestamp_list = []

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -204,6 +204,18 @@ def change_log_full(table_id):
     return output
 
 
+@bp.route("/table/<table_id>/tabular_change_log_weekly", methods=["GET"])
+@auth_requires_permission("view")
+def tabular_change_log_weekly(table_id, root_id):
+    disp = request.args.get("disp", default=False, type=toboolean)
+    weekly_tab_change_log = common.tabular_change_log_weekly(table_id)
+
+    if disp:
+        return weekly_tab_change_log.to_html()
+    else:
+        return weekly_tab_change_log.to_json()
+
+
 @bp.route("/table/<table_id>/root/<root_id>/change_log", methods=["GET"])
 @auth_requires_permission("view")
 def change_log(table_id, root_id):

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -204,11 +204,12 @@ def change_log_full(table_id):
     return output
 
 
-@bp.route("/table/<table_id>/tabular_change_log_weekly", methods=["GET"])
+@bp.route("/table/<table_id>/tabular_change_log_recent", methods=["GET"])
 @auth_requires_permission("view")
 def tabular_change_log_weekly(table_id):
+    start_time = request.args.get("start_time", default=0, type=int)
     disp = request.args.get("disp", default=False, type=toboolean)
-    weekly_tab_change_log = common.tabular_change_log_weekly(table_id)
+    weekly_tab_change_log = common.tabular_change_log_recent(table_id, start_time)
 
     if disp:
         return weekly_tab_change_log.to_html()

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -207,9 +207,8 @@ def change_log_full(table_id):
 @bp.route("/table/<table_id>/tabular_change_log_recent", methods=["GET"])
 @auth_requires_permission("view") #TODO: admin_view
 def tabular_change_log_weekly(table_id):
-    start_time = request.args.get("start_time", default=0, type=int) #TODO parsing
     disp = request.args.get("disp", default=False, type=toboolean)
-    weekly_tab_change_log = common.tabular_change_log_recent(table_id, start_time)
+    weekly_tab_change_log = common.tabular_change_log_recent(table_id)
 
     if disp:
         return weekly_tab_change_log.to_html()

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -206,7 +206,7 @@ def change_log_full(table_id):
 
 @bp.route("/table/<table_id>/tabular_change_log_weekly", methods=["GET"])
 @auth_requires_permission("view")
-def tabular_change_log_weekly(table_id, root_id):
+def tabular_change_log_weekly(table_id):
     disp = request.args.get("disp", default=False, type=toboolean)
     weekly_tab_change_log = common.tabular_change_log_weekly(table_id)
 

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -205,9 +205,9 @@ def change_log_full(table_id):
 
 
 @bp.route("/table/<table_id>/tabular_change_log_recent", methods=["GET"])
-@auth_requires_permission("view")
+@auth_requires_permission("view") #TODO: admin_view
 def tabular_change_log_weekly(table_id):
-    start_time = request.args.get("start_time", default=0, type=int)
+    start_time = request.args.get("start_time", default=0, type=int) #TODO parsing
     disp = request.args.get("disp", default=False, type=toboolean)
     weekly_tab_change_log = common.tabular_change_log_recent(table_id, start_time)
 

--- a/pychunkedgraph/backend/chunkedgraph.py
+++ b/pychunkedgraph/backend/chunkedgraph.py
@@ -1618,6 +1618,9 @@ class ChunkedGraph(object):
         ]
 
         log_records_d = self.read_node_id_rows(
+            start_id=np.uint64(0),
+            end_id=self.get_max_operation_id(),
+            end_id_inclusive=True,
             columns=columns,
             start_time=start_time,
             end_time=end_time,

--- a/pychunkedgraph/backend/chunkedgraph.py
+++ b/pychunkedgraph/backend/chunkedgraph.py
@@ -1548,53 +1548,15 @@ class ChunkedGraph(object):
         log_record.update((column, v[0].value) for column, v in log_record.items())
         return log_record, timestamp
 
-    def read_log_rows(self, operation_ids: Optional[Sequence] = None):
-        """ Retrieves log records from Bigtable for given operation IDs
-        If None, returns all operation rows
-        """
-        columns = [
-            column_keys.OperationLogs.UndoOperationID,
-            column_keys.OperationLogs.RedoOperationID,
-            column_keys.OperationLogs.UserID,
-            column_keys.OperationLogs.RootID,
-            column_keys.OperationLogs.SinkID,
-            column_keys.OperationLogs.SourceID,
-            column_keys.OperationLogs.SourceCoordinate,
-            column_keys.OperationLogs.SinkCoordinate,
-            column_keys.OperationLogs.AddedEdge,
-            column_keys.OperationLogs.Affinity,
-            column_keys.OperationLogs.RemovedEdge,
-            column_keys.OperationLogs.BoundingBoxOffset,
-        ]
-        if operation_ids is None:
-            log_records_d = self.read_node_id_rows(
-                start_id=np.uint64(0),
-                end_id=self.get_max_operation_id(),
-                end_id_inclusive=True,
-                columns=columns
-            )
-        else:
-            log_records_d = self.read_node_id_rows(
-                node_ids=operation_ids, columns=columns
-            )
-
-        if len(log_records_d) == 0:
-            return {}
-
-        for operation_id in log_records_d:
-            log_record = log_records_d[operation_id]
-            timestamp = log_record[column_keys.OperationLogs.RootID][0].timestamp
-            log_record.update((column, v[0].value) for column, v in log_record.items())
-            log_record["timestamp"] = timestamp
-
-        return log_records_d
-
-    def read_log_rows_for_timespan(self, start_time: Optional[datetime.datetime] = None,
+    def read_log_rows(self, operation_ids: Optional[Sequence] = None,
+            start_time: Optional[datetime.datetime] = None,
             end_time: Optional[datetime.datetime] = None,
             end_time_inclusive: bool = False):
-        """ Retrieves log records from Bigtable for all operations in given timespan
+        """ Retrieves log records from Bigtable.
 
         Keyword Arguments:
+            operation_ids {Optional[datetime.datetime]} -- IDs of operations to limit to. If None,
+                operations will not be limited by ID. (default: {None})
             start_time {Optional[datetime.datetime]} -- Ignore cells with timestamp before
                 `start_time`. If None, no lower bound. (default: {None})
             end_time {Optional[datetime.datetime]} -- Ignore cells with timestamp after `end_time`.
@@ -1616,16 +1578,24 @@ class ChunkedGraph(object):
             column_keys.OperationLogs.RemovedEdge,
             column_keys.OperationLogs.BoundingBoxOffset,
         ]
-
-        log_records_d = self.read_node_id_rows(
-            start_id=np.uint64(0),
-            end_id=self.get_max_operation_id(),
-            end_id_inclusive=True,
-            columns=columns,
-            start_time=start_time,
-            end_time=end_time,
-            end_time_inclusive=end_time_inclusive
-        )
+        if operation_ids is None:
+            log_records_d = self.read_node_id_rows(
+                start_id=np.uint64(0),
+                end_id=self.get_max_operation_id(),
+                end_id_inclusive=True,
+                columns=columns,
+                start_time=start_time,
+                end_time=end_time,
+                end_time_inclusive=end_time_inclusive
+            )
+        else:
+            log_records_d = self.read_node_id_rows(
+                node_ids=operation_ids,
+                columns=columns,
+                start_time=start_time,
+                end_time=end_time,
+                end_time_inclusive=end_time_inclusive
+            )
 
         if len(log_records_d) == 0:
             return {}

--- a/pychunkedgraph/backend/history.py
+++ b/pychunkedgraph/backend/history.py
@@ -388,7 +388,7 @@ def get_tabular_changelog_weekly(cg_instance):
     for entry_id in entry_ids:
         entry = log_rows[entry_id]
 
-        raise Error('entry: ' + str(entry))
+        raise Exception('entry: ' + str(entry))
         timestamp_list.append(entry["timestamp"])
         user_list.append(entry.user_id)
 

--- a/pychunkedgraph/backend/history.py
+++ b/pychunkedgraph/backend/history.py
@@ -358,33 +358,10 @@ def get_tabular_changelog_weekly(cg_instance):
     start_time = datetime.datetime.now() - datetime.timedelta(days=7)
     log_rows = cg_instance.read_log_rows_for_timespan(start_time=start_time)
 
-    """
-            row_dict = self.cg.read_node_id_rows(node_ids=next_ids)
-
-            for row_key, row in row_dict.items():
-                
-                # Read log row and add it to the dict
-                if operation_id_col in row and row_key != self.root_id:
-                    operation_id = row[operation_id_col][0].value
-
-                    if operation_id in self._past_log_rows:
-                        continue
-                else:
-                    if row_key != self.root_id:
-                        raise cg_exceptions.InternalServerError
-                    else:
-                        continue
-
-                log_row, log_timestamp = self.cg.read_log_row(operation_id)
-
-                self._past_log_rows[operation_id] = LogEntry(log_row,
-                                                             log_timestamp)
-    """
-
     timestamp_list = []
     user_list = []
 
-    entry_ids = np.sort(list(log_rows.keys())) #TODO is this necessary to sort? or is it already sorted
+    entry_ids = np.sort(list(log_rows.keys()))
     for entry_id in entry_ids:
         entry = log_rows[entry_id]
 
@@ -394,23 +371,7 @@ def get_tabular_changelog_weekly(cg_instance):
         user_id = entry[column_keys.OperationLogs.UserID]
         user_list.append(user_id)
 
-        #raise Exception('entry: ' + str(entry))
-
     return pd.DataFrame.from_dict(
         {"operation_id": entry_ids,
             "timestamp": timestamp_list,
             "user_id": user_list})
-
-    """
-    for operation_id in range(cg_instance.get_max_operation_id()):
-        try:
-            log_entries.append(
-                LogEntry(
-                    log_rows[operation_id],
-                    log_rows[operation_id]["timestamp"]
-                )
-            )
-        except KeyError:
-            continue
-    return log_entries
-    """

--- a/pychunkedgraph/backend/history.py
+++ b/pychunkedgraph/backend/history.py
@@ -353,8 +353,7 @@ def get_all_log_entries(cg_instance):
             continue
     return log_entries
 
-def get_tabular_changelog_recent(cg_instance, start_time_int):
-    start_time = datetime.datetime.fromtimestamp(start_time_int / 1000.0)
+def get_tabular_changelog_recent(cg_instance, start_time):
     log_rows = cg_instance.read_log_rows(start_time=start_time)
 
     timestamp_list = []

--- a/pychunkedgraph/backend/history.py
+++ b/pychunkedgraph/backend/history.py
@@ -388,9 +388,13 @@ def get_tabular_changelog_weekly(cg_instance):
     for entry_id in entry_ids:
         entry = log_rows[entry_id]
 
-        raise Exception('entry: ' + str(entry))
-        timestamp_list.append(entry["timestamp"])
-        user_list.append(entry.user_id)
+        timestamp = entry["timestamp"]
+        timestamp_list.append(timestamp)
+
+        user_id = entry[column_keys.OperationLogs.UserID]
+        user_list.append(user_id)
+
+        #raise Exception('entry: ' + str(entry))
 
     return pd.DataFrame.from_dict(
         {"operation_id": entry_ids,

--- a/pychunkedgraph/backend/history.py
+++ b/pychunkedgraph/backend/history.py
@@ -355,7 +355,7 @@ def get_all_log_entries(cg_instance):
 
 def get_tabular_changelog_recent(cg_instance, start_time_int):
     start_time = datetime.datetime.fromtimestamp(start_time_int / 1000.0)
-    log_rows = cg_instance.read_log_rows_for_timespan(start_time=start_time)
+    log_rows = cg_instance.read_log_rows(start_time=start_time)
 
     timestamp_list = []
     user_list = []

--- a/pychunkedgraph/backend/history.py
+++ b/pychunkedgraph/backend/history.py
@@ -352,24 +352,3 @@ def get_all_log_entries(cg_instance):
         except KeyError:
             continue
     return log_entries
-
-def get_tabular_changelog_recent(cg_instance, start_time):
-    log_rows = cg_instance.read_log_rows(start_time=start_time)
-
-    timestamp_list = []
-    user_list = []
-
-    entry_ids = np.sort(list(log_rows.keys()))
-    for entry_id in entry_ids:
-        entry = log_rows[entry_id]
-
-        timestamp = entry["timestamp"]
-        timestamp_list.append(timestamp)
-
-        user_id = entry[column_keys.OperationLogs.UserID]
-        user_list.append(user_id)
-
-    return pd.DataFrame.from_dict(
-        {"operation_id": entry_ids,
-            "timestamp": timestamp_list,
-            "user_id": user_list})

--- a/pychunkedgraph/backend/history.py
+++ b/pychunkedgraph/backend/history.py
@@ -388,7 +388,8 @@ def get_tabular_changelog_weekly(cg_instance):
     for entry_id in entry_ids:
         entry = log_rows[entry_id]
 
-        timestamp_list.append(entry.timestamp)
+        raise Error('entry: ' + str(entry))
+        timestamp_list.append(entry["timestamp"])
         user_list.append(entry.user_id)
 
     return pd.DataFrame.from_dict(

--- a/pychunkedgraph/backend/history.py
+++ b/pychunkedgraph/backend/history.py
@@ -353,9 +353,8 @@ def get_all_log_entries(cg_instance):
             continue
     return log_entries
 
-def get_tabular_changelog_weekly(cg_instance):
-    log_entries = []
-    start_time = datetime.datetime.now() - datetime.timedelta(days=7)
+def get_tabular_changelog_recent(cg_instance, start_time_int):
+    start_time = datetime.datetime.fromtimestamp(start_time_int / 1000.0)
     log_rows = cg_instance.read_log_rows_for_timespan(start_time=start_time)
 
     timestamp_list = []

--- a/pychunkedgraph/backend/history.py
+++ b/pychunkedgraph/backend/history.py
@@ -352,3 +352,60 @@ def get_all_log_entries(cg_instance):
         except KeyError:
             continue
     return log_entries
+
+def get_tabular_changelog_weekly(cg_instance):
+    log_entries = []
+    start_time = datetime.datetime.now() - datetime.timedelta(days=7)
+    log_rows = cg_instance.read_log_rows_for_timespan(start_time=start_time)
+
+    """
+            row_dict = self.cg.read_node_id_rows(node_ids=next_ids)
+
+            for row_key, row in row_dict.items():
+                
+                # Read log row and add it to the dict
+                if operation_id_col in row and row_key != self.root_id:
+                    operation_id = row[operation_id_col][0].value
+
+                    if operation_id in self._past_log_rows:
+                        continue
+                else:
+                    if row_key != self.root_id:
+                        raise cg_exceptions.InternalServerError
+                    else:
+                        continue
+
+                log_row, log_timestamp = self.cg.read_log_row(operation_id)
+
+                self._past_log_rows[operation_id] = LogEntry(log_row,
+                                                             log_timestamp)
+    """
+
+    timestamp_list = []
+    user_list = []
+
+    entry_ids = np.sort(list(log_rows.keys())) #TODO is this necessary to sort? or is it already sorted
+    for entry_id in entry_ids:
+        entry = log_rows[entry_id]
+
+        timestamp_list.append(entry.timestamp)
+        user_list.append(entry.user_id)
+
+    return pd.DataFrame.from_dict(
+        {"operation_id": entry_ids,
+            "timestamp": timestamp_list,
+            "user_id": user_list})
+
+    """
+    for operation_id in range(cg_instance.get_max_operation_id()):
+        try:
+            log_entries.append(
+                LogEntry(
+                    log_rows[operation_id],
+                    log_rows[operation_id]["timestamp"]
+                )
+            )
+        except KeyError:
+            continue
+    return log_entries
+    """


### PR DESCRIPTION
Adds a `/tabular_change_log_weekly` page that returns all edits made in the past week (starting from the current time of day, 7 days ago) in a tabular form, for use in the Flywire leaderboard. It includes operation_id, timestamp, and user_id.

We might want to make this more flexible in the future to allow any start time, and maybe any end time, by taking those as parameters in the URL. If we do this the permission should probably be changed from `@auth_requires_permission("view")` to `@auth_requires_admin`, since it could get all edits like `/change_log` can.

If there's a better way to get all records for a given time than passing start_id=0 and end_id=max to `read_node_id_rows`, let me know, but it doesn't seem too slow in practice. Feedback on code structure/style is also welcome.