### PR TITLE
added mesh job priority feature

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -318,7 +318,15 @@ def handle_l2_chunk_children(table_id, chunk_id, as_array):
             l2_chunk_dict[k] = rr_chunk[k][0].value
 
         return l2_chunk_dict
-
+        
+def trigger_remesh(new_lvl2_ids, is_priority=True):
+    auth_header = {"Authorization": f"Bearer {current_app.config['AUTH_TOKEN']}"}
+    resp = requests.post(f"{current_app.config['MESHING_ENDPOINT']}/api/v1/table/{table_id}/remeshing",
+                            data=json.dumps({"new_lvl2_ids": new_lvl2_ids},
+                                            cls=current_app.json_encoder), 
+                            params={'priority': is_priority},
+                            headers=auth_header)
+    resp.raise_for_status()
 
 ### MERGE ----------------------------------------------------------------------
 
@@ -327,6 +335,7 @@ def handle_merge(table_id):
     current_app.table_id = table_id
 
     nodes = json.loads(request.data)
+    is_priority = request.params.get('priority', True )
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
 
@@ -389,12 +398,8 @@ def handle_merge(table_id):
     current_app.logger.debug(("lvl2_nodes:", ret.new_lvl2_ids))
 
     if len(ret.new_lvl2_ids) > 0:
-        auth_header = {"Authorization": f"Bearer {current_app.config['AUTH_TOKEN']}"}
-        resp = requests.post(f"{current_app.config['MESHING_ENDPOINT']}/api/v1/table/{table_id}/remeshing",
-                             data=json.dumps({"new_lvl2_ids": ret.new_lvl2_ids},
-                                             cls=current_app.json_encoder), 
-                             headers=auth_header)
-        resp.raise_for_status()
+        trigger_remesh(ret.new_lvl2_ids, is_priority=is_priority)
+
 
     return ret
 
@@ -406,6 +411,7 @@ def handle_split(table_id):
     current_app.table_id = table_id
 
     data = json.loads(request.data)
+    is_priority = request.params.get('priority', True )
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
 
@@ -467,12 +473,8 @@ def handle_split(table_id):
     current_app.logger.debug(("lvl2_nodes:", ret.new_lvl2_ids))
 
     if len(ret.new_lvl2_ids) > 0:
-        auth_header = {"Authorization": f"Bearer {current_app.config['AUTH_TOKEN']}"}
-        resp = requests.post(f"{current_app.config['MESHING_ENDPOINT']}/api/v1/table/{table_id}/remeshing",
-                             data=json.dumps({"new_lvl2_ids": ret.new_lvl2_ids},
-                                             cls=current_app.json_encoder), 
-                             headers=auth_header)
-        resp.raise_for_status()
+        trigger_remesh(ret.new_lvl2_ids, is_priority=is_priority)
+
 
     return ret
 
@@ -484,6 +486,7 @@ def handle_undo(table_id):
     current_app.table_id = table_id
 
     data = json.loads(request.data)
+    is_priority = request.params.get('priority', True )
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
 
@@ -506,12 +509,8 @@ def handle_undo(table_id):
     current_app.logger.debug(("lvl2_nodes:", ret.new_lvl2_ids))
 
     if ret.new_lvl2_ids.size > 0:
-        auth_header = {"Authorization": f"Bearer {current_app.config['AUTH_TOKEN']}"}
-        resp = requests.post(f"{current_app.config['MESHING_ENDPOINT']}/api/v1/table/{table_id}/remeshing",
-                             data=json.dumps({"new_lvl2_ids": ret.new_lvl2_ids},
-                                             cls=current_app.json_encoder), 
-                             headers=auth_header)
-        resp.raise_for_status()
+        trigger_remesh(ret.new_lvl2_ids, is_priority=is_priority)
+
 
     return ret
 
@@ -523,6 +522,7 @@ def handle_redo(table_id):
     current_app.table_id = table_id
 
     data = json.loads(request.data)
+    is_priority = request.params.get('priority', True )
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
 
@@ -545,14 +545,10 @@ def handle_redo(table_id):
     current_app.logger.debug(("lvl2_nodes:", ret.new_lvl2_ids))
 
     if ret.new_lvl2_ids.size > 0:
-        auth_header = {"Authorization": f"Bearer {current_app.config['AUTH_TOKEN']}"}
-        resp = requests.post(f"{current_app.config['MESHING_ENDPOINT']}/api/v1/table/{table_id}/remeshing",
-                             data=json.dumps({"new_lvl2_ids": ret.new_lvl2_ids},
-                                             cls=current_app.json_encoder), 
-                             headers=auth_header)
-        resp.raise_for_status()
+        trigger_remesh(ret.new_lvl2_ids, is_priority=is_priority)
 
     return ret
+
 
 
 ### CHILDREN -------------------------------------------------------------------

--- a/rq_workers/mesh_worker.py
+++ b/rq_workers/mesh_worker.py
@@ -15,7 +15,7 @@ from rq import Connection, Worker, Queue
 #     REDIS_URL = f'redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/0'
 
 # Queues to listen on
-QUEUES = ['default', 'mesh-chunks']
+QUEUES = ['mesh-chunks','mesh-chunks-low-priority']
 
 # If you're using Sentry to collect your runtime exceptions, you can use this
 # to configure RQ for it in a single step
@@ -30,7 +30,7 @@ app = create_app()
 redis_connection = redis.from_url(app.config["REDIS_URL"])
 with app.app_context():
     with Connection(redis_connection):
-        worker = Worker(["mesh-chunks"],
+        worker = Worker(QUEUES,
                         default_worker_ttl=600,
                         job_monitoring_interval=1)
         worker.work()


### PR DESCRIPTION
I've added an optional query parameter to split, merge, redo, undo.  priority=False, which defaults to True, but if False, will pass the priority onto the meshing service, which will change which redis queue this is placed in.  This will effectively prioritize priority=True (or priority omitted) requests, over priority=False requests.  Automated processes can use priority=False in order to make sure to prioritize human interactions over machine interactions in when things are remeshed.  This interface could be used in the future to extend into other parts of the system. 

I've also added 3 retries to the meshing jobs to cut down on the number of failed jobs, and made the retry period more aggressive for priority jobs vs non-priority jobs.