### PR TITLE
Feat: faster get subgraph when requesting many nodes + many leaves endpoint

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -592,6 +592,34 @@ def handle_leaves(table_id, root_id):
     return atomic_ids
 
 
+### LEAVES OF MANY ROOTS ---------------------------------------------------------------------
+
+
+def handle_leaves_many(table_id):
+    current_app.table_id = table_id
+    user_id = str(g.auth_user["id"])
+    current_app.user_id = user_id
+
+    if "bounds" in request.args:
+        bounds = request.args["bounds"]
+        bounding_box = np.array(
+            [b.split("-") for b in bounds.split("_")], dtype=np.int
+        ).T
+    else:
+        bounding_box = None
+
+    root_ids = np.array(json.loads(request.data)["root_ids"], dtype=np.uint64)
+
+    # Call ChunkedGraph
+    cg = app_utils.get_cg(table_id)
+
+    root_to_leaves_mapping = cg.get_subgraph_nodes(
+        root_ids, bbox=bounding_box, bbox_is_coordinate=True, return_layers=[1], serializable=True
+    )
+
+    return root_to_leaves_mapping
+
+
 ### LEAVES FROM LEAVES ---------------------------------------------------------
 
 

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -208,8 +208,7 @@ def handle_leaves(table_id, node_id):
 def handle_leaves_many(table_id):
     int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     resp = {"root_to_leaves_mapping": common.handle_leaves_many(table_id)}
-    jsonified = jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
-    return jsonified
+    return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
 
 
 ### SUBGRAPH -------------------------------------------------------------------

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -203,6 +203,15 @@ def handle_leaves(table_id, node_id):
     return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
 
 
+@bp.route("/table/<table_id>/node/leaves_many", methods=["POST"])
+@auth_requires_permission("view")
+def handle_leaves_many(table_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
+    resp = {"root_to_leaves_mapping": common.handle_leaves_many(table_id)}
+    jsonified = jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
+    return jsonified
+
+
 ### SUBGRAPH -------------------------------------------------------------------
 
 

--- a/pychunkedgraph/graph/chunkedgraph.py
+++ b/pychunkedgraph/graph/chunkedgraph.py
@@ -122,13 +122,7 @@ class ChunkedGraph:
         if self.get_chunk_layer(parent_id) == 1:
             return parent_id
         return id_helpers.get_atomic_id_from_coord(
-            self.meta,
-            self.get_root,
-            x,
-            y,
-            z,
-            parent_id,
-            n_tries=n_tries,
+            self.meta, self.get_root, x, y, z, parent_id, n_tries=n_tries,
         )
 
     def get_parents(
@@ -231,10 +225,7 @@ class ChunkedGraph:
         return node_children_d
 
     def _get_children_multiple(
-        self,
-        node_ids: typing.Iterable[np.uint64],
-        *,
-        raw_only=False,
+        self, node_ids: typing.Iterable[np.uint64], *, raw_only=False,
     ) -> typing.Dict:
         if raw_only or not self.cache:
             node_children_d = self.client.read_nodes(
@@ -249,10 +240,7 @@ class ChunkedGraph:
         return self.cache.children_multiple(node_ids)
 
     def get_atomic_cross_edges(
-        self,
-        l2_ids: typing.Iterable,
-        *,
-        raw_only=False,
+        self, l2_ids: typing.Iterable, *, raw_only=False,
     ) -> typing.Dict[np.uint64, typing.Dict[int, typing.Iterable]]:
         """Returns cross edges for level 2 IDs."""
         if raw_only or not self.cache:
@@ -499,22 +487,31 @@ class ChunkedGraph:
         leaves_only: bool = False,
         n_threads: int = 1,
     ) -> typing.Tuple[typing.Dict, typing.Dict, Edges]:
-        """TODO docs"""
-        single = False
+        if nodes_only:
+            return self.get_subgraph_nodes(
+                node_id_or_ids, bbox, bbox_is_coordinate, return_layers
+            )
+        return self.get_subgraph_edges_and_leaves(
+            node_id_or_ids, bbox, bbox_is_coordinate, edges_only, leaves_only, n_threads
+        )
+
+    def get_subgraph_edges_and_leaves(
+        self,
+        node_id_or_ids: typing.Union[np.uint64, typing.Iterable],
+        bbox: typing.Optional[typing.Sequence[typing.Sequence[int]]] = None,
+        bbox_is_coordinate: bool = False,
+        edges_only: bool = False,
+        leaves_only: bool = False,
+        n_threads: int = 1,
+    ) -> typing.Tuple[typing.Dict, typing.Dict, Edges]:
+        """Get the edges and/or leaves of the specified node_ids within the specified bounding box."""
         node_ids = node_id_or_ids
         bbox = chunk_utils.normalize_bounding_box(self.meta, bbox, bbox_is_coordinate)
         if isinstance(node_id_or_ids, np.uint64) or isinstance(node_id_or_ids, int):
-            single = True
             node_ids = [node_id_or_ids]
-        layer_nodes_d = {}
-        for node_id in node_ids:
-            layer_nodes_d[node_id] = self._get_subgraph_higher_layer_nodes(
-                node_id=node_id, bounding_box=bbox, return_layers=return_layers + [2],
-            )
-        if nodes_only:
-            if single:
-                return layer_nodes_d[node_id_or_ids]
-            return layer_nodes_d
+        layer_nodes_d = self._get_subgraph_multiple_nodes(
+            node_ids=node_ids, bounding_box=bbox, return_layers=[2], serializable=False
+        )
         level2_ids = [types.empty_1d]
         for node_id in node_ids:
             level2_ids.append(layer_nodes_d[node_id][2])
@@ -529,6 +526,33 @@ class ChunkedGraph:
             level2_ids, n_threads=n_threads
         )
         return l2id_agglomeration_d, edges
+
+    def get_subgraph_nodes(
+        self,
+        node_id_or_ids: typing.Union[np.uint64, typing.Iterable],
+        bbox: typing.Optional[typing.Sequence[typing.Sequence[int]]] = None,
+        bbox_is_coordinate: bool = False,
+        return_layers: typing.List = [2],
+        serializable: bool = False,
+        n_threads: int = 1,
+    ) -> typing.Tuple[typing.Dict, typing.Dict, Edges]:
+        """Get the children of the specified node_ids that are at each of the specified
+        return_layers within the specified bounding box."""
+        single = False
+        node_ids = node_id_or_ids
+        bbox = chunk_utils.normalize_bounding_box(self.meta, bbox, bbox_is_coordinate)
+        if isinstance(node_id_or_ids, np.uint64) or isinstance(node_id_or_ids, int):
+            single = True
+            node_ids = [node_id_or_ids]
+        layer_nodes_d = self._get_subgraph_multiple_nodes(
+            node_ids=node_ids,
+            bounding_box=bbox,
+            return_layers=return_layers,
+            serializable=serializable,
+        )
+        if single:
+            return layer_nodes_d[node_id_or_ids]
+        return layer_nodes_d
 
     def get_fake_edges(
         self, chunk_ids: np.ndarray, time_stamp: datetime.datetime = None
@@ -549,10 +573,7 @@ class ChunkedGraph:
         return result
 
     def get_l2_agglomerations(
-        self,
-        level2_ids: np.ndarray,
-        edges_only: bool = False,
-        n_threads: int = 1,
+        self, level2_ids: np.ndarray, edges_only: bool = False, n_threads: int = 1,
     ) -> typing.Tuple[typing.Dict[int, types.Agglomeration], np.ndarray]:
         """
         Children of Level 2 Node IDs and edges.
@@ -735,65 +756,63 @@ class ChunkedGraph:
         ).execute()
 
     # PRIVATE
-    def _get_subgraph_higher_layer_nodes(
+    def _get_subgraph_multiple_nodes(
         self,
-        node_id: np.uint64,
+        node_ids: typing.Iterable[np.uint64],
         bounding_box: typing.Optional[typing.Sequence[typing.Sequence[int]]],
         return_layers: typing.Sequence[int],
+        serializable: bool,
     ):
-        def _get_subgraph_higher_layer_nodes_threaded(
-            node_ids: typing.Iterable[np.uint64],
-        ) -> typing.List[np.uint64]:
-            children = self.get_children(node_ids, flatten=True)
-            if len(children) > 0 and bounding_box is not None:
-                bound_check_mask = misc_utils.mask_nodes_by_bounding_box(
-                    self.meta, children, bounding_box
-                )
-                children = children[bound_check_mask]
+        assert len(return_layers) > 0
 
+        def _get_dict_key(raw_key):
+            if serializable:
+                return str(raw_key)
+            return raw_key
+
+        def _get_subgraph_multiple_nodes_threaded(
+            node_ids_batch: typing.Iterable[np.uint64],
+        ) -> typing.List[np.uint64]:
+            children = self.get_children(np.sort(node_ids_batch))
+            if bounding_box is not None:
+                filtered_children = {}
+                for node_id, nodes_children in children.items():
+                    if self.get_chunk_layer(node_id) == 2:
+                        # All children will be in same chunk so no need to check
+                        filtered_children[_get_dict_key(node_id)] = nodes_children
+                        continue
+                    bound_check_mask = misc_utils.mask_nodes_by_bounding_box(
+                        self.meta, nodes_children, bounding_box
+                    )
+                    filtered_children[_get_dict_key(node_id)] = nodes_children[
+                        bound_check_mask
+                    ]
+                return filtered_children
             return children
 
         if bounding_box is not None:
             bounding_box = np.array(bounding_box)
 
-        layer = self.get_chunk_layer(node_id)
-        assert layer > 1
+        subgraph_progress = misc_utils.SubgraphProgress(
+            self.meta, node_ids, return_layers, serializable
+        )
 
-        nodes_per_layer = {}
-        child_ids = np.array([node_id], dtype=np.uint64)
-        stop_layer = max(2, np.min(return_layers))
-
-        if layer in return_layers:
-            nodes_per_layer[layer] = child_ids
-
-        while layer > stop_layer:
-            # Use heuristic to guess the optimal number of threads
-            child_id_layers = self.get_chunk_layers(child_ids)
-            this_layer_m = child_id_layers == layer
-            this_layer_child_ids = child_ids[this_layer_m]
-            next_layer_child_ids = child_ids[~this_layer_m]
-
-            n_child_ids = len(child_ids)
-            this_n_threads = np.min([int(n_child_ids // 50000) + 1, mu.n_cpus])
-
-            from itertools import chain
-
-            child_ids = np.fromiter(
-                chain.from_iterable(
-                    mu.multithread_func(
-                        _get_subgraph_higher_layer_nodes_threaded,
-                        np.array_split(this_layer_child_ids, this_n_threads),
-                        n_threads=this_n_threads,
-                        debug=this_n_threads == 1,
-                    )
-                ),
-                np.uint64,
+        while not subgraph_progress.done_processing():
+            this_n_threads = np.min(
+                [int(len(subgraph_progress.cur_nodes) // 50000) + 1, mu.n_cpus]
             )
-            child_ids = np.concatenate([child_ids, next_layer_child_ids])
-            layer -= 1
-            if layer in return_layers:
-                nodes_per_layer[layer] = child_ids
-        return nodes_per_layer
+            cur_nodes_child_maps = mu.multithread_func(
+                _get_subgraph_multiple_nodes_threaded,
+                np.array_split(subgraph_progress.cur_nodes, this_n_threads),
+                n_threads=this_n_threads,
+                debug=this_n_threads == 1,
+            )
+            from collections import ChainMap
+
+            cur_nodes_children = dict(ChainMap(*cur_nodes_child_maps))
+            subgraph_progress.process_batch_of_children(cur_nodes_children)
+
+        return subgraph_progress.node_to_subgraph
 
     def _get_bounding_l2_children(self, parent_ids: typing.Iterable) -> typing.Dict:
         """

--- a/pychunkedgraph/graph/utils/generic.py
+++ b/pychunkedgraph/graph/utils/generic.py
@@ -21,6 +21,7 @@ from google.cloud import bigtable
 from google.cloud.bigtable.row_filters import RowFilter
 from cloudvolume import CloudVolume
 
+from .. import types
 from ..chunks import utils as chunk_utils
 from . import serializers
 
@@ -189,3 +190,100 @@ def mask_nodes_by_bounding_box(
         ).T
 
         return np.all(bound_check, axis=1)
+
+
+class SubgraphProgress:
+    """
+    Helper class to keep track of node relationships
+    while calling cg.get_subgraph(node_ids)
+    """
+
+    def __init__(self, meta, node_ids, return_layers, serializable):
+        self.meta = meta
+        self.node_ids = node_ids
+        self.return_layers = return_layers
+        self.serializable = serializable
+
+        self.node_to_subgraph = {}
+        # "Frontier" of nodes that cg.get_children will be called on
+        self.cur_nodes = np.array(list(node_ids), dtype=np.uint64)
+        # Mapping of current frontier to self.node_ids
+        self.cur_nodes_to_original_nodes = dict(zip(self.cur_nodes, self.cur_nodes))
+        self.stop_layer = max(1, np.min(return_layers))
+        self.create_initial_node_to_subgraph()
+
+    def done_processing(self):
+        return self.cur_nodes is None or len(self.cur_nodes) is 0
+
+    def create_initial_node_to_subgraph(self):
+        """
+        Create initial subgraph. We will incrementally populate after processing
+        each batch of children, and return it when there are no more to process.
+        """
+        for node_id in self.cur_nodes:
+            node_key = self.get_dict_key(node_id)
+            self.node_to_subgraph[node_key] = {}
+            for return_layer in self.return_layers:
+                self.node_to_subgraph[node_key][return_layer] = []
+            node_layer = chunk_utils.get_chunk_layer(self.meta, node_id)
+            if node_layer in self.return_layers:
+                self.node_to_subgraph[node_key][node_layer].append([node_id])
+
+    def get_dict_key(self, node_id):
+        if self.serializable:
+            return str(node_id)
+        return node_id
+
+    def process_batch_of_children(self, cur_nodes_children):
+        """
+        Given children of self.cur_nodes, update subgraph and
+        produce next frontier (if any). 
+        """
+        next_nodes_to_process = []
+        next_nodes_to_original_nodes_keys = []
+        next_nodes_to_original_nodes_values = []
+        for cur_node, children in cur_nodes_children.items():
+            children_layers = chunk_utils.get_chunk_layers(self.meta, children)
+            continue_mask = children_layers > self.stop_layer
+            continue_children = children[continue_mask]
+            original_id = self.cur_nodes_to_original_nodes[np.uint64(cur_node)]
+            if len(continue_children) > 0:
+                # These nodes will be in next frontier
+                next_nodes_to_process.append(continue_children)
+                next_nodes_to_original_nodes_keys.append(continue_children)
+                next_nodes_to_original_nodes_values.append(
+                    [original_id] * len(continue_children)
+                )
+            for return_layer in self.return_layers:
+                # Update subgraph for each return_layer
+                children_at_layer = children[children_layers == return_layer]
+                if len(children_at_layer) > 0:
+                    self.node_to_subgraph[self.get_dict_key(original_id)][
+                        return_layer
+                    ].append(children_at_layer)
+
+        if len(next_nodes_to_process) == 0:
+            self.cur_nodes = None
+            # We are done, so we can concatenate/flatten each entry in node_to_subgraph
+            self.flatten_subgraph()
+        else:
+            self.cur_nodes = np.concatenate(next_nodes_to_process)
+            self.cur_nodes_to_original_nodes = dict(
+                zip(
+                    np.concatenate(next_nodes_to_original_nodes_keys),
+                    np.concatenate(next_nodes_to_original_nodes_values),
+                )
+            )
+
+    def flatten_subgraph(self):
+        # Flatten each entry in node_to_subgraph before returning
+        for node_id in self.node_ids:
+            for return_layer in self.return_layers:
+                node_key = self.get_dict_key(node_id)
+                children_at_layer = self.node_to_subgraph[node_key][return_layer]
+                if len(children_at_layer) > 0:
+                    self.node_to_subgraph[node_key][return_layer] = np.concatenate(
+                        children_at_layer
+                    )
+                else:
+                    self.node_to_subgraph[node_key][return_layer] = types.empty_1d

--- a/pychunkedgraph/graph/utils/generic.py
+++ b/pychunkedgraph/graph/utils/generic.py
@@ -213,7 +213,7 @@ class SubgraphProgress:
         self.create_initial_node_to_subgraph()
 
     def done_processing(self):
-        return self.cur_nodes is None or len(self.cur_nodes) is 0
+        return self.cur_nodes is None or len(self.cur_nodes) == 0
 
     def create_initial_node_to_subgraph(self):
         """


### PR DESCRIPTION
Refactored `get_subgraph` such that it requests the subgraph of several nodes at once as opposed to one at a time. For 20 nodes, observed 2-3x speedup during local testing. Also added endpoint so Neuroglancer can request the leaves of many nodes at a time. This will cut the number of http requests Neuroglancer has to make substantially when many segments are selected. Also fixed a minor bug in `get_subgraph` -- `return_layers` was not always respected when it was not [2] in the previous logic, because of skip connections (within the repo, it was always called with `return_layers = [2]`, so not a big deal). 