### PR TITLE
adding start_layer=6 for speculative manifests

### DIFF
--- a/pychunkedgraph/app/meshing/common.py
+++ b/pychunkedgraph/app/meshing/common.py
@@ -188,7 +188,10 @@ def handle_get_manifest(table_id, node_id):
     prepend_seg_ids = request.args.get("prepend_seg_ids", False)
     return_seg_ids = return_seg_ids in ["True", "true", "1", True]
     prepend_seg_ids = prepend_seg_ids in ["True", "true", "1", True]
-    start_layer = cg.get_chunk_layer(np.uint64(node_id))
+    if verify:
+        start_layer = cg.get_chunk_layer(np.uint64(node_id))
+    else:
+        start_layer = 6
     if "start_layer" in data:
         start_layer = int(data["start_layer"])
 


### PR DESCRIPTION
In order to address #232  for now, i am suggesting adding start_layer=6 as the value for verify=False when None is specified.  This was accomplished before by the default keyword value on get_children_before_start_layer

(https://github.com/seung-lab/PyChunkedGraph/blob/akhilesh-unit-tests/pychunkedgraph/meshing/manifest.py#L277)

However, now that start_layer is always being passed down, it needs to be set higher up.

Really I feel this is metadata on the state of initial meshing, and is rightfully thus metadata for the meshing service associated with this graph, but we don't have a place for that now I don't believe.
