### PR TITLE
adding level2 graph get endpoint

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -993,7 +993,20 @@ def handle_find_path(table_id, precision_mode):
             "l2_path": l2_path
         }
 
+### GET_LAYER2_SUBGRAPH
+def handle_get_layer2_graph(table_id, node_id):
+    current_app.table_id = table_id
+    user_id = str(g.auth_user["id"])
+    current_app.user_id = user_id
 
+    cg = app_utils.get_cg(table_id)
+    print("Finding edge graph...")
+    edge_graph = pathing.get_lvl2_edge_list(cg, node_id)
+    print("Edge graph found len: {}".format(len(edge_graph)))
+    return {
+        'edge_graph': edge_graph
+    }
+    
 ### IS LATEST ROOTS --------------------------------------------------------------
 
 def handle_is_latest_roots(table_id, is_binary):

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -361,3 +361,11 @@ def handle_roots_from_coords(table_id):
     int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     resp = common.handle_roots_from_coord(table_id)
     return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
+
+## Get level2 graph -------------------------------------------------------------
+@bp.route("/table/<table_id>/node/<node_id>/lvl2_graph", methods=["GET"])
+@auth_requires_permission("view")
+def handle_get_lvl2_graph(table_id, node_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
+    resp = common.handle_get_layer2_graph(table_id, node_id)
+    return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)


### PR DESCRIPTION
I'd like to open up the level2 graph used in the find_path tool to other applications.  We think we can use this to make very low resolution skeletons of neurons, and make a more dynamic proofreading process.

This PR breaks the level2 graph construction code in find path into another function, and then exposes that function via an api, and refactors the get_path code to call this new function. 

Assuming this restructuring makes sense and works, we can port this approach to the master version as well to keep the APIs at parity.