### PR TITLE
use timestamp from node_id for remeshing

### DIFF
--- a/pychunkedgraph/graph/chunkedgraph.py
+++ b/pychunkedgraph/graph/chunkedgraph.py
@@ -636,7 +636,7 @@ class ChunkedGraph:
         )
 
     def get_node_timestamps(
-        self, node_ids: typing.Sequence[np.uint64]
+        self, node_ids: typing.Sequence[np.uint64], return_numpy=True
     ) -> typing.Iterable:
         """
         The timestamp of the children column can be assumed
@@ -647,10 +647,14 @@ class ChunkedGraph:
         )
 
         if not children:
-            return np.array([], dtype=np.datetime64)
-        return np.array(
-            [children[x][0].timestamp for x in node_ids], dtype=np.datetime64
-        )
+            if return_numpy:
+                return np.array([], dtype=np.datetime64)
+            return []
+        if return_numpy:
+            return np.array(
+                [children[x][0].timestamp for x in node_ids], dtype=np.datetime64
+            )
+        return [children[x][0].timestamp for x in node_ids]
 
     # OPERATIONS
     def add_edges(

--- a/pychunkedgraph/meshing/meshgen.py
+++ b/pychunkedgraph/meshing/meshgen.py
@@ -815,12 +815,8 @@ def black_out_dust_from_segmentation(seg, dust_threshold):
 
 
 def _get_timestamp_from_node_ids(cg, node_ids):
-    parents = cg.client.read_nodes(node_ids=node_ids, properties=attributes.Hierarchy.Parent)
-    newest_timestamp = None
-    for node in node_ids:
-        if newest_timestamp is None or newest_timestamp < parents[node][0].timestamp:
-            newest_timestamp = parents[node][0].timestamp
-    return newest_timestamp + datetime.timedelta(milliseconds=1)
+    timestamps = cg.get_node_timestamps(node_ids, return_numpy=False)
+    return max(timestamps) + datetime.timedelta(milliseconds=1)
 
 def remeshing(
     cg,

--- a/pychunkedgraph/meshing/meshgen.py
+++ b/pychunkedgraph/meshing/meshgen.py
@@ -818,8 +818,8 @@ def _get_timestamp_from_node_ids(cg, node_ids):
     parents = cg.client.read_nodes(node_ids=node_ids, properties=attributes.Hierarchy.Parent)
     newest_timestamp = None
     for node in node_ids:
-        if newest_timestamp is None or newest_timestamp < parents[node][-1].timestamp:
-            newest_timestamp = parents[node][-1].timestamp
+        if newest_timestamp is None or newest_timestamp < parents[node][0].timestamp:
+            newest_timestamp = parents[node][0].timestamp
     return newest_timestamp + datetime.timedelta(milliseconds=1)
 
 def remeshing(


### PR DESCRIPTION
Instead of relying on `datetime.utcnow()` to produce the correct timestamp for remeshing, use the node_id's timestamp instead. Could possibly prevent instances of issue #239 