### PR TITLE
Removing meshing's reliance on CG Server

### DIFF
--- a/pychunkedgraph/meshing/meshgen.py
+++ b/pychunkedgraph/meshing/meshgen.py
@@ -296,14 +296,18 @@ def calculate_stop_layer(cg, chunk_id):
         for y in range(chunk_coords[1], chunk_coords[1] + 2):
             for z in range(chunk_coords[2], chunk_coords[2] + 2):
 
+                # Chunk id
+                neigh_chunk_id = cg.get_chunk_id(x=x, y=y, z=z, layer=chunk_layer)
                 try:
-                    # Chunk id
-                    neigh_chunk_id = cg.get_chunk_id(x=x, y=y, z=z, layer=chunk_layer)
                     # Get parent chunk ids
                     parent_chunk_ids = cg.get_parent_chunk_ids(neigh_chunk_id)
                     neigh_chunk_ids.append(neigh_chunk_id)
                     neigh_parent_chunk_ids.append(parent_chunk_ids)
                 except:
+                    # cg.get_parent_chunk_id can fail if neigh_chunk_id is outside the dataset
+                    # (only happens when cg.meta.bitmasks[chunk_layer+1] == log(max(x,y,z)),
+                    # so only for specific datasets in which the # of chunks in the widest dimension
+                    # just happens to be a power of two)
                     pass
 
     # Find lowest common chunk

--- a/pychunkedgraph/meshing/meshgen.py
+++ b/pychunkedgraph/meshing/meshgen.py
@@ -1291,7 +1291,6 @@ def chunk_initial_sharded_stitching_task(
         cur_chunk_id = int(cg.get_chunk_id(child_node))
         chunk_to_id_dict[cur_chunk_id].append(child_node)
 
-    # cv = CloudVolume(cv_graphene_path, mesh_dir=cv_mesh_dir)
     cv = CloudVolume(
         f"graphene://https://localhost/segmentation/table/dummy",
         info=meshgen_utils.get_json_info(cg),

--- a/pychunkedgraph/meshing/meshgen.py
+++ b/pychunkedgraph/meshing/meshgen.py
@@ -1275,7 +1275,7 @@ def chunk_stitch_remeshing_task(
 
 
 def chunk_initial_sharded_stitching_task(
-    cg_name, chunk_id, mip, cv_mesh_dir=None, cg=None, high_padding=1, cache=True
+    cg_name, chunk_id, mip, cg=None, high_padding=1, cache=True
 ):
     start_existence_check_time = time.time()
     if cg is None:

--- a/pychunkedgraph/meshing/meshgen_utils.py
+++ b/pychunkedgraph/meshing/meshgen_utils.py
@@ -149,7 +149,7 @@ def get_json_info(cg):
 
 
 def get_ws_seg_for_chunk(cg, chunk_id, mip, overlap_vx=1):
-    cv = CloudVolume(cg.meta.cv.cloudpath, mip=mip)
+    cv = CloudVolume(cg.meta.cv.cloudpath, mip=mip, fill_missing=True)
     mip_diff = mip - cg.meta.cv.mip
 
     mip_chunk_size = np.array(cg.meta.graph_config.CHUNK_SIZE, dtype=np.int) / np.array(

--- a/pychunkedgraph/meshing/meshgen_utils.py
+++ b/pychunkedgraph/meshing/meshgen_utils.py
@@ -149,7 +149,7 @@ def get_json_info(cg):
 
 
 def get_ws_seg_for_chunk(cg, chunk_id, mip, overlap_vx=1):
-    cv = CloudVolume(cg.meta.cv.cloudpath, mip=mip, fill_missing=True)
+    cv = CloudVolume(cg.meta.cv.cloudpath, mip=mip)
     mip_diff = mip - cg.meta.cv.mip
 
     mip_chunk_size = np.array(cg.meta.graph_config.CHUNK_SIZE, dtype=np.int) / np.array(

--- a/pychunkedgraph/meshing/meshing_batch.py
+++ b/pychunkedgraph/meshing/meshing_batch.py
@@ -15,7 +15,6 @@ if __name__ == "__main__":
     parser.add_argument('--skip_cache', action='store_true')
 
     args = parser.parse_args()
-    cv_mesh_dir = 'graphene_meshes'
     cache = not args.skip_cache
 
     cg = ChunkedGraph(graph_id=args.cg_name)
@@ -34,7 +33,7 @@ if __name__ == "__main__":
         def __iter__(self):
             for chunk in self.chunks:
                 chunk_id = cg.get_chunk_id(layer=args.layer, x=chunk[0], y=chunk[1], z=chunk[2])
-                yield MeshTask(args.cg_name, args.layer, int(chunk_id), args.mip, cv_mesh_dir, cache)
+                yield MeshTask(args.cg_name, args.layer, int(chunk_id), args.mip, cache)
 
     if args.queue_name is not None:
         with TaskQueue(queue_name=args.queue_name) as tq:

--- a/pychunkedgraph/meshing/meshing_batch.py
+++ b/pychunkedgraph/meshing/meshing_batch.py
@@ -12,10 +12,11 @@ if __name__ == "__main__":
     parser.add_argument('--cg_name', type=str)
     parser.add_argument('--layer', type=int)
     parser.add_argument('--mip', type=int)
-    parser.add_argument('--graphene_path', type=str)
+    parser.add_argument('--skip_cache', action='store_true')
 
     args = parser.parse_args()
     cv_mesh_dir = 'graphene_meshes'
+    cache = not args.skip_cache
 
     cg = ChunkedGraph(graph_id=args.cg_name)
 
@@ -33,7 +34,7 @@ if __name__ == "__main__":
         def __iter__(self):
             for chunk in self.chunks:
                 chunk_id = cg.get_chunk_id(layer=args.layer, x=chunk[0], y=chunk[1], z=chunk[2])
-                yield MeshTask(args.cg_name, args.layer, int(chunk_id), args.mip, args.graphene_path, cv_mesh_dir)
+                yield MeshTask(args.cg_name, args.layer, int(chunk_id), args.mip, cv_mesh_dir, cache)
 
     if args.queue_name is not None:
         with TaskQueue(queue_name=args.queue_name) as tq:

--- a/pychunkedgraph/meshing/meshing_sqs.py
+++ b/pychunkedgraph/meshing/meshing_sqs.py
@@ -10,7 +10,6 @@ class MeshTask(RegisteredTask):
     def execute(self):
         cg_name = self.cg_name
         chunk_id = np.uint64(self.chunk_id)
-        cv_mesh_dir = self.cv_mesh_dir
         mip = self.mip
         layer = self.layer
         if layer == 2:

--- a/pychunkedgraph/meshing/meshing_sqs.py
+++ b/pychunkedgraph/meshing/meshing_sqs.py
@@ -4,8 +4,8 @@ import numpy as np
 
 
 class MeshTask(RegisteredTask):
-    def __init__(self, cg_name, layer, chunk_id, mip, cv_mesh_dir, cache=True):
-        super().__init__(cg_name, layer, chunk_id, mip, cv_mesh_dir, cache)
+    def __init__(self, cg_name, layer, chunk_id, mip, cache=True):
+        super().__init__(cg_name, layer, chunk_id, mip, cache)
 
     def execute(self):
         cg_name = self.cg_name
@@ -20,12 +20,11 @@ class MeshTask(RegisteredTask):
                 None,
                 mip=mip,
                 sharded=True,
-                cv_mesh_dir=cv_mesh_dir,
                 cache=self.cache
             )
         else:
             result = meshgen.chunk_initial_sharded_stitching_task(
-                cg_name, chunk_id, mip, cv_mesh_dir, cache=self.cache
+                cg_name, chunk_id, mip, cache=self.cache
             )
         print(result)
 

--- a/pychunkedgraph/meshing/meshing_sqs.py
+++ b/pychunkedgraph/meshing/meshing_sqs.py
@@ -4,13 +4,12 @@ import numpy as np
 
 
 class MeshTask(RegisteredTask):
-    def __init__(self, cg_name, layer, chunk_id, mip, cv_graphene_path, cv_mesh_dir):
-        super().__init__(cg_name, layer, chunk_id, mip, cv_graphene_path, cv_mesh_dir)
+    def __init__(self, cg_name, layer, chunk_id, mip, cv_mesh_dir, cache=True):
+        super().__init__(cg_name, layer, chunk_id, mip, cv_mesh_dir, cache)
 
     def execute(self):
         cg_name = self.cg_name
         chunk_id = np.uint64(self.chunk_id)
-        cv_graphene_path = self.cv_graphene_path
         cv_mesh_dir = self.cv_mesh_dir
         mip = self.mip
         layer = self.layer
@@ -21,12 +20,12 @@ class MeshTask(RegisteredTask):
                 None,
                 mip=mip,
                 sharded=True,
-                cv_graphene_path=cv_graphene_path,
                 cv_mesh_dir=cv_mesh_dir,
+                cache=self.cache
             )
         else:
             result = meshgen.chunk_initial_sharded_stitching_task(
-                cg_name, chunk_id, mip, cv_graphene_path, cv_mesh_dir
+                cg_name, chunk_id, mip, cv_mesh_dir, cache=self.cache
             )
         print(result)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+urllib3==1.25.11
 -e git+https://github.com/ZettaAI/cloud-volume.git@nkem-float-res-fix#egg=cloud-volume
 numpy
 pandas
@@ -17,5 +18,5 @@ middle-auth-client==2.4.3
 fastremap
 pyyaml
 cachetools
-task-queue
+task-queue==1.0.0
 cloud-files


### PR DESCRIPTION
Meshing creates a CV instance to retrieve meshes and mesh-related info. That CV instance currently points to the CG Server, but that is unnecessary, as we can simply pass the info file in instead. 