### PR TITLE
assert roots flag

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -260,7 +260,7 @@ def handle_roots(table_id, is_binary=False):
     cg = app_utils.get_cg(table_id)
     stop_layer = int(request.args.get("stop_layer", cg.meta.layer_count))
     is_root_layer = stop_layer == cg.meta.layer_count
-    assert_roots = request.args.get("assert_roots", True)
+    assert_roots = bool(request.args.get("assert_roots", True))
     root_ids = cg.get_roots(
         node_ids,
         stop_layer=stop_layer,

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -259,11 +259,13 @@ def handle_roots(table_id, is_binary=False):
 
     cg = app_utils.get_cg(table_id)
     stop_layer = int(request.args.get("stop_layer", cg.meta.layer_count))
+    is_root_layer = stop_layer == cg.meta.layer_count
+    assert_roots = request.args.get("assert_roots", True)
     root_ids = cg.get_roots(
         node_ids,
         stop_layer=stop_layer,
         time_stamp=timestamp,
-        assert_roots=stop_layer == cg.meta.layer_count,
+        assert_roots=assert_roots and is_root_layer,
     )
 
     return root_ids

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -260,7 +260,7 @@ def handle_roots(table_id, is_binary=False):
     cg = app_utils.get_cg(table_id)
     stop_layer = int(request.args.get("stop_layer", cg.meta.layer_count))
     is_root_layer = stop_layer == cg.meta.layer_count
-    assert_roots = bool(request.args.get("assert_roots", True))
+    assert_roots = bool(request.args.get("assert_roots", False))
     root_ids = cg.get_roots(
         node_ids,
         stop_layer=stop_layer,


### PR DESCRIPTION
There are a small subset of supervoxels in minnie that are surrounded by id=0, which caused them to have no parents in the agglomeration graph, and thus calling get_roots on them fails to get a parent at the root level.  This in term causes cloud-volume to error when converting these blocks to a flat segmentation via a 503 error on the get_roots call triggered by agglomerate=True.  

This PR adds an optional flag "assert_roots" which defaults to True to enforce that all the roots must map to a rootID.  This was before being set to True only if asking for the stop_layer to be the top layer.. now you must be asking for the top_layer AND have assert_roots=True.  We are then free to change cloud-volume to use assert_roots=False by default, or as an option.   

I still need to test this out fully and make a PR to cloud-volume, but i'm opening this PR to initiate discussion over this as  the approach. 