### PR TITLE
Add find_path coarse precision

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -1024,7 +1024,7 @@ def handle_split_preview(table_id):
 ### FIND PATH --------------------------------------------------------------
 
 
-def handle_find_path(table_id):
+def handle_find_path(table_id, precision_mode):
     current_app.table_id = table_id
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
@@ -1059,13 +1059,20 @@ def handle_find_path(table_id):
     target_l2_id = cg.get_parent(target_supervoxel_id)
 
     l2_path = analysis.find_l2_shortest_path(cg, source_l2_id, target_l2_id)
-    centroids, failed_l2_ids = analysis.compute_mesh_centroids_of_l2_ids(cg, l2_path, flatten=True)
-
-    return {
-        "centroids_list": centroids,
-        "failed_l2_ids": failed_l2_ids,
-        "l2_path": l2_path
-    }
+    if precision_mode:
+        centroids, failed_l2_ids = analysis.compute_mesh_centroids_of_l2_ids(cg, l2_path, flatten=True)
+        return {
+            "centroids_list": centroids,
+            "failed_l2_ids": failed_l2_ids,
+            "l2_path": l2_path
+        }
+    else:
+        centroids = analysis.compute_rough_coordinate_path(cg, l2_path)
+        return {
+            "centroids_list": centroids,
+            "failed_l2_ids": [],
+            "l2_path": l2_path
+        }
 
 ### GET_LAYER2_SUBGRAPH
 def handle_get_layer2_graph(table_id, node_id):

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -370,7 +370,8 @@ def last_edit(table_id, root_id):
 @auth_requires_permission("view")
 def find_path(table_id):
     int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
-    find_path_result = common.handle_find_path(table_id)
+    precision_mode = request.args.get("precision_mode", default=True, type=toboolean)
+    find_path_result = common.handle_find_path(table_id, precision_mode)
     return jsonify_with_kwargs(find_path_result, int64_as_str=int64_as_str)
 
 ## GET LEVEL2 GRAPH -------------------------------------------------------------

--- a/pychunkedgraph/graph_analysis/analysis.py
+++ b/pychunkedgraph/graph_analysis/analysis.py
@@ -185,3 +185,23 @@ def compute_mesh_centroids_of_l2_ids(cg, l2_ids, flatten=False):
                 failed_l2_ids.append(l2_id)
             last_l2_id = l2_id
     return centroids_with_chunk_boundary_points, failed_l2_ids
+
+
+def compute_rough_coordinate_path(cg, l2_ids):
+    """
+    Given a list of l2_ids, return a list of rough coordinates representing
+    the path the l2_ids form.
+    :param cg: ChunkedGraph object
+    :param l2_ids: Sequence[np.uint64]
+    :return: [np.ndarray]
+    """
+    coordinate_path = []
+    for l2_id in l2_ids:
+        chunk_center = cg.get_chunk_coordinates(l2_id) + np.array([0.5, 0.5, 0.5])
+        coordinate = chunk_center * np.array(
+            cg.meta.graph_config.CHUNK_SIZE
+        ) + np.array(cg.meta.cv.mip_voxel_offset(0))
+        coordinate = coordinate * np.array(cg.meta.cv.mip_resolution(0))
+        coordinate = coordinate.astype(np.float32)
+        coordinate_path.append(coordinate)
+    return coordinate_path


### PR DESCRIPTION
Add flag to find_path that enables a coarse path to be returned (one that does not require meshes).  This functionality already exists in the minnie branch.