### PR TITLE
Csm mincut robustness fix

### DIFF
--- a/pychunkedgraph/graph/cutting.py
+++ b/pychunkedgraph/graph/cutting.py
@@ -221,7 +221,7 @@ class LocalMincutGraph:
                 self.weighted_graph_raw, self.capacities_raw, self.sink_graph_ids, self.source_graph_ids)
         except AssertionError:
             raise PreconditionError(
-                "Paths between source or sink points irrepairably overlap other labels from other side. "
+                "Paths between source or sink points irreparably overlap other labels from other side. "
                 "Check that labels are correct and consider spreading points out farther."
             )
 

--- a/pychunkedgraph/graph/cutting.py
+++ b/pychunkedgraph/graph/cutting.py
@@ -138,6 +138,16 @@ class LocalMincutGraph:
         self.source_path_vertices = self.source_graph_ids
         self.sink_path_vertices = self.sink_graph_ids
 
+        if flatgraph.labels_connected(self.weighted_graph_raw, self.source_graph_ids):
+            self.allow_source_isolated = True
+        else:
+            self.allow_source_isolated = False
+
+        if flatgraph.labels_connected(self.weighted_graph_raw, self.sink_graph_ids):
+            self.allow_sink_isolated = True
+        else:
+            self.allow_sink_isolated = False
+
         dt = time.time() - time_start
         if logger is not None:
             logger.debug("Graph creation: %.2fms" % (dt * 1000))
@@ -520,13 +530,15 @@ class LocalMincutGraph:
                     assert np.all(np.in1d(self.source_graph_ids, cc))
                     assert ~np.any(np.in1d(self.sink_graph_ids, cc))
                     if len(self.source_path_vertices) == len(cc) and self.disallow_isolating_cut:
-                        raise IsolatingCutException('Source')
+                        if not self.allow_source_isolated:
+                            raise IsolatingCutException('Source')
 
                 if np.any(np.in1d(self.sink_graph_ids, cc)):
                     assert np.all(np.in1d(self.sink_graph_ids, cc))
                     assert ~np.any(np.in1d(self.source_graph_ids, cc))
                     if len(self.sink_path_vertices) == len(cc) and self.disallow_isolating_cut:
-                        raise IsolatingCutException('Sink')
+                        if not self.allow_sink_isolated:
+                            raise IsolatingCutException('Sink')
 
         except AssertionError:
             if self.split_preview:

--- a/pychunkedgraph/graph/utils/flatgraph.py
+++ b/pychunkedgraph/graph/utils/flatgraph.py
@@ -171,6 +171,17 @@ def remove_overlapping_edges(paths_v_s, paths_e_s,
         return path_e_s_out, path_e_y_out, True
 
 
+def labels_connected(graph, label_vertices):
+    """Based on the initial graph and a set of vertices, decides if all connected
+    """
+    label_filter = np.full(graph.num_vertices(), False)
+    label_filter[label_vertices] = True
+    vfilt = graph.new_vertex_property('bool', vals=label_filter)
+    gfilt = GraphView(graph, vfilt=vfilt)
+    _, count = topology.label_components(gfilt)
+    return len(count) == 1
+
+
 def check_connectedness(vertices, edges, expected_number=1):
     """Returns True if the augmenting edges still form a single connected component
     """

--- a/pychunkedgraph/graph/utils/flatgraph.py
+++ b/pychunkedgraph/graph/utils/flatgraph.py
@@ -171,17 +171,6 @@ def remove_overlapping_edges(paths_v_s, paths_e_s,
         return path_e_s_out, path_e_y_out, True
 
 
-def labels_connected(graph, label_vertices):
-    """Based on the initial graph and a set of vertices, decides if all connected
-    """
-    label_filter = np.full(graph.num_vertices(), False)
-    label_filter[label_vertices] = True
-    vfilt = graph.new_vertex_property('bool', vals=label_filter)
-    gfilt = GraphView(graph, vfilt=vfilt)
-    _, count = topology.label_components(gfilt)
-    return len(count) == 1
-
-
 def check_connectedness(vertices, edges, expected_number=1):
     """Returns True if the augmenting edges still form a single connected component
     """

--- a/pychunkedgraph/graph/utils/flatgraph.py
+++ b/pychunkedgraph/graph/utils/flatgraph.py
@@ -183,7 +183,8 @@ def check_connectedness(vertices, edges, expected_number=1):
 
     g2 = Graph(directed=False)
     g2.add_vertex(n=len(paths_inds))
-    g2.add_edge_list(edge_list_remap)
+    if len(edge_list_remap) > 0:
+        g2.add_edge_list(np.atleast_2d(edge_list_remap))
 
     _, count = topology.label_components(g2)
     return len(count) == expected_number

--- a/pychunkedgraph/tests/test_uncategorized.py
+++ b/pychunkedgraph/tests/test_uncategorized.py
@@ -2525,7 +2525,7 @@ class TestGraphMinCut:
                 cg.meta.graph_config.CHUNK_SIZE[2],
             ],
             mincut=True,
-            disallow_isolating_cut=False,
+            disallow_isolating_cut=True,
         ).new_root_ids
 
         # Check New State


### PR DESCRIPTION
This PR makes three changes to the split algorithm to fix bugs and improve robustness.

1) I now catch a case where a zero-length list was passed to a graph_tool function which couldn't handle it, which fixes the `Invalid type for edge list` error.
2) When paths overlap, I perform one additional fallback. If giving the overlap region to one team causes there to be no paths for between labeled points of the other team, I swap ownership of the overlap region and try one last time before raising an error.
3) I improved the logic for isolating cuts so that they are now allowed in only the case that all edges from the cut region are onto nodes from the initial set of labels : I.e. if blue is going to be an isolated split, all adjacent supervoxels on the other side must be human-labeled. This should allow laborious manual splitting of small merges.