### PR TITLE
Fixing dependency issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM gcr.io/neuromancer-seung-import/pychunkedgraph:graph-tool_dracopy
 COPY override/timeout.conf /etc/nginx/conf.d/timeout.conf
 COPY override/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY . /app
-RUN pip install pip=20.2 \
+RUN pip install pip==20.2 \
     && pip install --no-cache-dir --upgrade -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM gcr.io/neuromancer-seung-import/pychunkedgraph:graph-tool_dracopy
 COPY override/timeout.conf /etc/nginx/conf.d/timeout.conf
 COPY override/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY . /app
-RUN pip install --upgrade pip \
+RUN pip install pip=20.2 \
     && pip install --no-cache-dir --upgrade -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cloud-files==1.24.1
+cloud-files>=1.25.2
 pyopenssl
 cloud-volume
 numpy


### PR DESCRIPTION
The new pip resolver breaks with cloud-files>=1.25.2. Downgrading pip to 20.2 worked but we should not use it for long. tbh, we did not see another way out of this. 