### PR TITLE
Training changes ported to v2

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -502,7 +502,7 @@ def handle_undo(table_id):
     operation_id = np.uint64(data["operation_id"])
 
     try:
-        ret = cg.undo(user_id=user_id, operation_id=operation_id)
+        ret = cg.undo_operation(user_id=user_id, operation_id=operation_id)
     except cg_exceptions.LockingError as e:
         raise cg_exceptions.InternalServerError(e)
     except (cg_exceptions.PreconditionError, cg_exceptions.PostconditionError) as e:
@@ -536,7 +536,7 @@ def handle_redo(table_id):
     operation_id = np.uint64(data["operation_id"])
 
     try:
-        ret = cg.redo(user_id=user_id, operation_id=operation_id)
+        ret = cg.redo_operation(user_id=user_id, operation_id=operation_id)
     except cg_exceptions.LockingError as e:
         raise cg_exceptions.InternalServerError(e)
     except (cg_exceptions.PreconditionError, cg_exceptions.PostconditionError) as e:

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -22,6 +22,7 @@ from pychunkedgraph.app import app_utils
 from pychunkedgraph.graph import attributes, cutting, exceptions as cg_exceptions, edges as cg_edges
 from pychunkedgraph.graph import segmenthistory
 from pychunkedgraph.graph.analysis import pathing
+from pychunkedgraph.graph.attributes import OperationLogs
 from pychunkedgraph.meshing import mesh_analysis
 
 __api_versions__ = [0, 1]
@@ -615,7 +616,7 @@ def all_user_operations(table_id):
     entry_ids = np.sort(list(log_rows.keys()))
     for entry_id in entry_ids:
         entry = log_rows[entry_id]
-        user_id = entry[column_keys.OperationLogs.UserID]
+        user_id = entry[OperationLogs.UserID]
 
         if user_id == target_user_id:
             valid_entry_ids.append(entry_id)
@@ -623,7 +624,7 @@ def all_user_operations(table_id):
             timestamp_list.append(timestamp)
 
     return {"operation_id": valid_entry_ids,
-         "timestamp": timestamp_list}
+            "timestamp": timestamp_list}
 
 
 ### CHILDREN -------------------------------------------------------------------

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -417,6 +417,7 @@ def handle_split(table_id):
 
     data = json.loads(request.data)
     is_priority = request.args.get('priority', True, type=str2bool)
+    mincut = request.args.get('mincut', True, type=str2bool)
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
 
@@ -459,7 +460,7 @@ def handle_split(table_id):
             sink_ids=data_dict["sinks"]["id"],
             source_coords=data_dict["sources"]["coord"],
             sink_coords=data_dict["sinks"]["coord"],
-            mincut=True,
+            mincut=mincut,
         )
 
     except cg_exceptions.LockingError as e:

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -606,9 +606,9 @@ def all_user_operations(table_id):
         )
 
     # Call ChunkedGraph
-    cg_instance = app_utils.get_cg(table_id)
+    cg = app_utils.get_cg(table_id)
 
-    log_rows = cg_instance.read_log_rows(start_time=start_time)
+    log_rows = cg.client.read_log_entries(start_time=start_time)
 
     valid_entry_ids = []
     timestamp_list = []

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -802,43 +802,43 @@ def change_log(table_id, root_id=None):
     return hist.change_log()
 
 
-# def tabular_change_log_recent(table_id):
-#     current_app.table_id = table_id
-#     user_id = str(g.auth_user["id"])
-#     current_app.user_id = user_id
+def tabular_change_log_recent(table_id):
+    current_app.table_id = table_id
+    user_id = str(g.auth_user["id"])
+    current_app.user_id = user_id
 
-#     try:
-#         start_time = float(request.args.get("start_time", 0))
-#         start_time = datetime.fromtimestamp(start_time, UTC)
-#     except (TypeError, ValueError):
-#         raise (
-#             cg_exceptions.BadRequest(
-#                 "start_time parameter is not a valid unix timestamp"
-#             )
-#         )
+    try:
+        start_time = float(request.args.get("start_time", 0))
+        start_time = datetime.fromtimestamp(start_time, UTC)
+    except (TypeError, ValueError):
+        raise (
+            cg_exceptions.BadRequest(
+                "start_time parameter is not a valid unix timestamp"
+            )
+        )
 
-#     # Call ChunkedGraph
-#     cg = app_utils.get_cg(table_id)
+    # Call ChunkedGraph
+    cg = app_utils.get_cg(table_id)
 
-#     log_rows = cg.read_log_rows(start_time=start_time)
+    log_rows = cg.client.read_log_entries(start_time=start_time)
 
-#     timestamp_list = []
-#     user_list = []
+    timestamp_list = []
+    user_list = []
 
-#     entry_ids = np.sort(list(log_rows.keys()))
-#     for entry_id in entry_ids:
-#         entry = log_rows[entry_id]
+    operation_ids = np.sort(list(log_rows.keys()))
+    for operation_id in operation_ids:
+        operation = log_rows[operation_id]
 
-#         timestamp = entry["timestamp"]
-#         timestamp_list.append(timestamp)
+        timestamp = operation["timestamp"]
+        timestamp_list.append(timestamp)
 
-#         user_id = entry[attributes.OperationLogs.UserID]
-#         user_list.append(user_id)
+        user_id = operation[attributes.OperationLogs.UserID]
+        user_list.append(user_id)
 
-#     return pd.DataFrame.from_dict(
-#         {"operation_id": entry_ids,
-#             "timestamp": timestamp_list,
-#             "user_id": user_list})
+    return pd.DataFrame.from_dict({
+        "operation_id": operation_ids,
+        "timestamp": timestamp_list,
+        "user_id": user_list})
 
 
 def tabular_change_log(table_id, root_id, get_root_ids, filtered):

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -1,6 +1,7 @@
 import io
 import csv
 import pickle
+import pandas as pd
 
 from flask import make_response, current_app
 from flask import Blueprint, request
@@ -126,6 +127,33 @@ def handle_redo(table_id):
     redo_result = common.handle_redo(table_id)
     resp = {"operation_id": redo_result.operation_id, "new_root_ids": redo_result.new_root_ids}
     return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
+
+
+### ROLLBACK USER --------------------------------------------------------------
+
+
+@bp.route("/table/<table_id>/rollback_user", methods=["POST"])
+@auth_requires_admin
+def handle_rollback(table_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
+    rollback_result = common.handle_rollback(table_id)
+    resp = rollback_result
+    return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
+
+
+### USER OPERATIONS -------------------------------------------------------------
+
+
+@bp.route("/table/<table_id>/user_operations", methods=["GET"])
+@auth_requires_permission("admin_view")
+def handle_user_operations(table_id):
+    disp = request.args.get("disp", default=False, type=toboolean)
+    user_operations = pd.DataFrame.from_dict(common.all_user_operations(table_id))
+
+    if disp:
+        return user_operations.to_html()
+    else:
+        return user_operations.to_json()
 
 
 ### GET ROOT -------------------------------------------------------------------

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -316,7 +316,7 @@ def change_log_full(table_id):
 
 
 @bp.route("/table/<table_id>/tabular_change_log_recent", methods=["GET"])
-@auth_requires_permission("view") #TODO: admin_view
+@auth_requires_permission("admin_view")
 def tabular_change_log_weekly(table_id):
     disp = request.args.get("disp", default=False, type=toboolean)
     weekly_tab_change_log = common.tabular_change_log_recent(table_id)

--- a/pychunkedgraph/graph/chunkedgraph.py
+++ b/pychunkedgraph/graph/chunkedgraph.py
@@ -116,10 +116,15 @@ class ChunkedGraph:
         )
 
     def get_atomic_id_from_coord(
-        self, x: int, y: int, z: int, parent_id: np.uint64, n_tries: int = 5
+        self,
+        x: int,
+        y: int,
+        z: int,
+        parent_id: Optional[np.uint64] = None,
+        n_tries: int = 5
     ) -> np.uint64:
         """Determines atomic id given a coordinate."""
-        if self.get_chunk_layer(parent_id) == 1:
+        if parent_id is not None and self.get_chunk_layer(parent_id) == 1:
             return parent_id
         return id_helpers.get_atomic_id_from_coord(
             self.meta, self.get_root, x, y, z, parent_id, n_tries=n_tries
@@ -763,10 +768,10 @@ class ChunkedGraph:
         :param operation_id: operation_id to be inverted
         :return: GraphEditOperation.Result
         """
-        return operation.UndoOperation(
+        return operation.GraphEditOperation.undo_operation(
             self,
             user_id=user_id,
-            superseded_operation_id=operation_id,
+            operation_id=operation_id,
             multicut_as_split=True,
         ).execute()
 
@@ -778,10 +783,10 @@ class ChunkedGraph:
         :param operation_id: operation_id to be repeated
         :return: GraphEditOperation.Result
         """
-        return operation.RedoOperation(
+        return operation.GraphEditOperation.redo_operation(
             self,
             user_id=user_id,
-            superseded_operation_id=operation_id,
+            operation_id=operation_id,
             multicut_as_split=True,
         ).execute()
 

--- a/pychunkedgraph/graph/chunkedgraph.py
+++ b/pychunkedgraph/graph/chunkedgraph.py
@@ -120,11 +120,11 @@ class ChunkedGraph:
         x: int,
         y: int,
         z: int,
-        parent_id: typing.Optional[np.uint64] = None,
+        parent_id: np.uint64,
         n_tries: int = 5
     ) -> np.uint64:
         """Determines atomic id given a coordinate."""
-        if parent_id is not None and self.get_chunk_layer(parent_id) == 1:
+        if self.get_chunk_layer(parent_id) == 1:
             return parent_id
         return id_helpers.get_atomic_id_from_coord(
             self.meta, self.get_root, x, y, z, parent_id, n_tries=n_tries

--- a/pychunkedgraph/graph/chunkedgraph.py
+++ b/pychunkedgraph/graph/chunkedgraph.py
@@ -120,7 +120,7 @@ class ChunkedGraph:
         x: int,
         y: int,
         z: int,
-        parent_id: Optional[np.uint64] = None,
+        parent_id: typing.Optional[np.uint64] = None,
         n_tries: int = 5
     ) -> np.uint64:
         """Determines atomic id given a coordinate."""

--- a/pychunkedgraph/graph/operation.py
+++ b/pychunkedgraph/graph/operation.py
@@ -977,7 +977,7 @@ class RedoOperation(GraphEditOperation):
             raise ValueError(
                 (
                     f"RedoOperation received {log_record_type.__name__} as target operation, "
-                    "which is not allowed. Use GraphEditOperation.create_redo() instead."
+                    "which is not allowed. Use GraphEditOperation.redo_operation() instead."
                 )
             )
 
@@ -1066,7 +1066,7 @@ class UndoOperation(GraphEditOperation):
             raise ValueError(
                 (
                     f"UndoOperation received {log_record_type.__name__} as target operation, "
-                    "which is not allowed. Use GraphEditOperation.create_undo() instead."
+                    "which is not allowed. Use GraphEditOperation.undo_operation() instead."
                 )
             )
 

--- a/pychunkedgraph/graph/utils/id_helpers.py
+++ b/pychunkedgraph/graph/utils/id_helpers.py
@@ -52,13 +52,18 @@ def get_atomic_id_from_coord(
     x: int,
     y: int,
     z: int,
-    parent_id: np.uint64,
+    parent_id: Optional[np.uint64] = None,
     n_tries: int = 5,
 ) -> np.uint64:
     """Determines atomic id given a coordinate."""
     x = int(x / 2 ** meta.data_source.CV_MIP)
     y = int(y / 2 ** meta.data_source.CV_MIP)
     z = int(z)
+
+    if parent_id is None:
+        # assume we have a single unique id at the exact coordinate
+        atomic_id_block = self.cv[x: x + 1, y: y + 1, z: z + 1]
+        return atomic_id_block[0][0][0][0]
 
     checked = []
     atomic_id = None

--- a/pychunkedgraph/graph/utils/id_helpers.py
+++ b/pychunkedgraph/graph/utils/id_helpers.py
@@ -52,18 +52,13 @@ def get_atomic_id_from_coord(
     x: int,
     y: int,
     z: int,
-    parent_id: Optional[np.uint64] = None,
+    parent_id: np.uint64,
     n_tries: int = 5,
 ) -> np.uint64:
     """Determines atomic id given a coordinate."""
     x = int(x / 2 ** meta.data_source.CV_MIP)
     y = int(y / 2 ** meta.data_source.CV_MIP)
     z = int(z)
-
-    if parent_id is None:
-        # assume we have a single unique id at the exact coordinate
-        atomic_id_block = self.cv[x: x + 1, y: y + 1, z: z + 1]
-        return atomic_id_block[0][0][0][0]
 
     checked = []
     atomic_id = None


### PR DESCRIPTION
Porting over the changes I made to v1. These are in master PRs #191, #212, #260, #267, #270, and #271. The code is almost identical, just had to change `cg.read_log_rows` to `cg.client.read_log_entries`.

The only additional changes are:
- a fix to `handle_undo` and `handle_redo` in `common.py`, to call `cg.undo_operation` and `cg.redo_operation` instead of the nonexistent `cg.undo` and `cg.redo`.
- add `added_edges` and `removed_edges` to the log entries for undo and redo operations as appropriate, so that you don't have to look up the undone/redone operation to find them.

These changes may get added to v1 separately.