### PR TITLE
Fix: v2 find path precision mode 

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -1123,6 +1123,7 @@ def handle_find_path(table_id, precision_mode):
 
     # Call ChunkedGraph
     cg = app_utils.get_cg(table_id)
+    root_time_stamp = cg.get_node_timestamps([np.uint64(nodes[0][0])], return_numpy=False)[0]
     def _get_supervoxel_id_from_node(node):
         node_id = node[0]
         x, y, z = node[1:]
@@ -1131,7 +1132,8 @@ def handle_find_path(table_id, precision_mode):
         supervoxel_id = cg.get_atomic_id_from_coord(coordinate[0],
                                                 coordinate[1],
                                                 coordinate[2],
-                                                parent_id=np.uint64(node_id))
+                                                parent_id=np.uint64(node_id),
+                                                time_stamp=root_time_stamp)
         if supervoxel_id is None:
             raise cg_exceptions.BadRequest(
                 f"Could not determine supervoxel ID for coordinates "
@@ -1149,7 +1151,7 @@ def handle_find_path(table_id, precision_mode):
     print(f'Source: {source_supervoxel_id}')
     print(f'Target: {target_supervoxel_id}')
 
-    l2_path = pathing.find_l2_shortest_path(cg, source_l2_id, target_l2_id)
+    l2_path = pathing.find_l2_shortest_path(cg, source_l2_id, target_l2_id, time_stamp=root_time_stamp)
     print(f'Path: {l2_path}')
     if precision_mode:
         centroids, failed_l2_ids = mesh_analysis.compute_mesh_centroids_of_l2_ids(cg, l2_path, flatten=True)

--- a/pychunkedgraph/graph/chunkedgraph.py
+++ b/pychunkedgraph/graph/chunkedgraph.py
@@ -121,13 +121,14 @@ class ChunkedGraph:
         y: int,
         z: int,
         parent_id: np.uint64,
-        n_tries: int = 5
+        n_tries: int = 5,
+        time_stamp: typing.Optional[datetime.datetime] = None,
     ) -> np.uint64:
         """Determines atomic id given a coordinate."""
         if self.get_chunk_layer(parent_id) == 1:
             return parent_id
         return id_helpers.get_atomic_id_from_coord(
-            self.meta, self.get_root, x, y, z, parent_id, n_tries=n_tries
+            self.meta, self.get_root, x, y, z, parent_id, n_tries=n_tries, time_stamp=time_stamp
         )
 
     def get_parents(

--- a/pychunkedgraph/graph/utils/id_helpers.py
+++ b/pychunkedgraph/graph/utils/id_helpers.py
@@ -4,6 +4,7 @@ Utils functions for node and segment IDs.
 
 from typing import Optional
 
+import datetime
 import numpy as np
 
 from . import basetypes
@@ -54,6 +55,7 @@ def get_atomic_id_from_coord(
     z: int,
     parent_id: np.uint64,
     n_tries: int = 5,
+    time_stamp: Optional[datetime.datetime] = None,
 ) -> np.uint64:
     """Determines atomic id given a coordinate."""
     x = int(x / 2 ** meta.data_source.CV_MIP)
@@ -62,7 +64,7 @@ def get_atomic_id_from_coord(
 
     checked = []
     atomic_id = None
-    root_id = get_root(parent_id)
+    root_id = get_root(parent_id, time_stamp=time_stamp)
 
     for i_try in range(n_tries):
         # Define block size -- increase by one each try
@@ -91,7 +93,7 @@ def get_atomic_id_from_coord(
         # given root id
         for candidate_atomic_id in sorted_atomic_ids:
             if candidate_atomic_id != 0:
-                ass_root_id = get_root(candidate_atomic_id)
+                ass_root_id = get_root(candidate_atomic_id, time_stamp=time_stamp)
                 if ass_root_id == root_id:
                     # atomic_id is not None will be our indicator that the
                     # search was successful

--- a/pychunkedgraph/meshing/mesh_analysis.py
+++ b/pychunkedgraph/meshing/mesh_analysis.py
@@ -1,4 +1,4 @@
-from cloudvolume import CloudVolume, Storage
+from cloudvolume import CloudVolume
 import numpy as np
 import os
 from pychunkedgraph.meshing import meshgen, meshgen_utils
@@ -68,43 +68,30 @@ def compute_mesh_centroids_of_l2_ids(cg, l2_ids, flatten=False):
         mesh_dir=cv_sharded_mesh_dir,
         info=meshgen_utils.get_json_info(cg),
     )
-    fragments_to_fetch = [
-        f"{l2_id}:0:{meshgen_utils.get_chunk_bbox_str(cg, cg.get_chunk_id(l2_id))}"
-        for l2_id in l2_ids
-    ]
+    meshes = cv.mesh.get_meshes_on_bypass(l2_ids, allow_missing=True)
     if flatten:
         centroids_with_chunk_boundary_points = []
     else:
         centroids_with_chunk_boundary_points = {}
     last_l2_id = None
-    failed_l2_ids = []
-    with Storage(cv_unsharded_mesh_path) as storage:
-        files_contents = storage.get_files(fragments_to_fetch)
-        fragment_map = meshgen.get_missing_initial_meshes(cv, files_contents)
-        for i in range(len(fragments_to_fetch)):
-            fragment_to_fetch = fragments_to_fetch[i]
-            l2_id = l2_ids[i]
-            try:
-                fragment = fragment_map[fragment_to_fetch]
-                if fragment["content"] is not None and fragment["error"] is None:
-                    if "skip_decode" in fragment:
-                        vertices = fragment["content"].vertices
-                    else:
-                        mesh = meshgen.decode_draco_mesh_buffer(fragment["content"])
-                        vertices = mesh["vertices"]
-                    if flatten:
-                        centroids_with_chunk_boundary_points.extend(
-                            compute_centroid_with_chunk_boundary(
-                                cg, vertices, l2_id, last_l2_id
-                            )
-                        )
-                    else:
-                        centroids_with_chunk_boundary_points[
-                            l2_id
-                        ] = compute_centroid_with_chunk_boundary(
-                            cg, vertices, l2_id, last_l2_id
-                        )
-            except:
-                failed_l2_ids.append(l2_id)
-            last_l2_id = l2_id
-    return centroids_with_chunk_boundary_points, failed_l2_ids
+    missing_l2_ids = []
+    for l2_id_i in l2_ids:
+        l2_id = int(l2_id_i)
+        try:
+            l2_mesh_vertices = meshes[l2_id].vertices
+            if flatten:
+                centroids_with_chunk_boundary_points.extend(
+                    compute_centroid_with_chunk_boundary(
+                        cg, l2_mesh_vertices, l2_id, last_l2_id
+                    )
+                )
+            else:
+                centroids_with_chunk_boundary_points[
+                    l2_id
+                ] = compute_centroid_with_chunk_boundary(
+                    cg, l2_mesh_vertices, l2_id, last_l2_id
+                )
+        except:
+            missing_l2_ids.append(l2_id)
+        last_l2_id = l2_id
+    return centroids_with_chunk_boundary_points, missing_l2_ids

--- a/pychunkedgraph/meshing/mesh_analysis.py
+++ b/pychunkedgraph/meshing/mesh_analysis.py
@@ -59,9 +59,13 @@ def compute_mesh_centroids_of_l2_ids(cg, l2_ids, flatten=False):
     :return: Union[Dict[np.uint64, np.ndarray], [np.uint64], [np.uint64]]
     """
     cv_sharded_mesh_dir = cg.meta.dataset_info["mesh"]
-    cv_unsharded_mesh_dir = cg.meta.dataset_info["mesh_metadata"]["unsharded_mesh_dir"]
+    cv_unsharded_mesh_dir = cg.meta.dataset_info["mesh_metadata"][
+        "unsharded_mesh_dir"
+    ]
     cv_unsharded_mesh_path = os.path.join(
-        cg.meta.data_source.WATERSHED, cv_sharded_mesh_dir, cv_unsharded_mesh_dir
+        cg.meta.data_source.WATERSHED,
+        cv_sharded_mesh_dir,
+        cv_unsharded_mesh_dir,
     )
     cv = CloudVolume(
         f"graphene://https://localhost/segmentation/table/dummy",


### PR DESCRIPTION
Fixes #296. Also fixes an additional bug I noticed: find path was not working for roots where `cg.get_root(sv_id) != root_id` for a selected `(root_id, sv_id)` pair in neuroglancer.  This is fixed by taking into account a root's initial timestamp in the `get_atomic_id_from_coord` function. This second bug is also existent in V1, so I will create a separate PR for that.