### PR TITLE
Fix: mesh stealing bug

### DIFF
--- a/pychunkedgraph/meshing/meshgen.py
+++ b/pychunkedgraph/meshing/meshgen.py
@@ -66,7 +66,6 @@ def remap_seg_using_unsafe_dict(seg, unsafe_dict):
         if np.sum(bin_seg) == 0:
             continue
 
-        l2_edges = []
         cc_seg, n_cc = ndimage.label(bin_seg)
         for i_cc in range(1, n_cc + 1):
             bin_cc_seg = cc_seg == i_cc
@@ -81,26 +80,8 @@ def remap_seg_using_unsafe_dict(seg, unsafe_dict):
 
             if len(linked_l2_ids) == 0:
                 seg[bin_cc_seg] = 0
-            elif len(linked_l2_ids) == 1:
-                seg[bin_cc_seg] = linked_l2_ids[0]
             else:
                 seg[bin_cc_seg] = linked_l2_ids[0]
-
-                for i_l2_id in range(len(linked_l2_ids) - 1):
-                    for j_l2_id in range(i_l2_id + 1, len(linked_l2_ids)):
-                        l2_edges.append(
-                            [linked_l2_ids[i_l2_id], linked_l2_ids[j_l2_id]]
-                        )
-
-        if len(l2_edges) > 0:
-            g = nx.Graph()
-            g.add_edges_from(l2_edges)
-
-            ccs = nx.connected_components(g)
-
-            for cc in ccs:
-                cc_ids = np.sort(list(cc))
-                seg[np.in1d(seg, cc_ids[1:]).reshape(seg.shape)] = cc_ids[0]
 
     return seg
 


### PR DESCRIPTION
Currently, when the mesh generation code generates meshes for a set of L2 ids in a chunk, it checks which of those L2 ids are connected in the overlap region, and maps all connected L2 ids to a single id. The result can look something like this:

![Screenshot from 2021-04-23 15-54-02](https://user-images.githubusercontent.com/4060940/115923604-7a39a500-a44c-11eb-92db-a0a2ee2cfff6.png)

This change only maps the overlap region to a single id, keeping the L2 ids within the chunk to be mapped to their own id. Here's what this example looks like after the change:

![Screenshot from 2021-04-23 15-57-38](https://user-images.githubusercontent.com/4060940/115923733-ad7c3400-a44c-11eb-88ea-3dc6df3c50bc.png)

