### PR TITLE
bugfix: typo on argument name

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -140,10 +140,10 @@ id_history = cg.read_agglomeration_id_history(root_id)
 
 To read the edge list and edge affinities of all atmic super voxels belonging to a root node do
 ```
-cg.get_subgraph(root_id, bounding_box, bb_is_coordinate=True)
+cg.get_subgraph(root_id, bounding_box, bbox_is_coordinate=True)
 ```
 
-The user can define a `bounding_box=[[x_l, y_l, z_l], [x_h, y_h, z_h]]` as either coordinates or chunk id range (use `bb_is_coordinate`). The `bounding_box` feature is currently not working, the parameter is ignored. The current datset is small enough to all reads of atomic supervoxels. Hence, this should not hinder any development.
+The user can define a `bounding_box=[[x_l, y_l, z_l], [x_h, y_h, z_h]]` as either coordinates or chunk id range (use `bbox_is_coordinate`). The `bounding_box` feature is currently not working, the parameter is ignored. The current datset is small enough to all reads of atomic supervoxels. Hence, this should not hinder any development.
 
 ##### Minimal example
 ```

--- a/pychunkedgraph/graph/chunks/utils.py
+++ b/pychunkedgraph/graph/chunks/utils.py
@@ -17,13 +17,13 @@ def get_chunks_boundary(voxel_boundary, chunk_size) -> np.ndarray:
 def normalize_bounding_box(
     meta,
     bounding_box: Optional[Sequence[Sequence[int]]],
-    bb_is_coordinate: bool,
+    bbox_is_coordinate: bool,
 ) -> Union[Sequence[Sequence[int]], None]:
     if bounding_box is None:
         return None
 
     bbox = bounding_box.copy()
-    if bb_is_coordinate:
+    if bbox_is_coordinate:
         bbox[0] = _get_chunk_coordinates_from_vol_coordinates(
             meta,
             bbox[0][0],

--- a/pychunkedgraph/graph/misc.py
+++ b/pychunkedgraph/graph/misc.py
@@ -167,7 +167,7 @@ def get_contact_sites(
     cg: ChunkedGraph,
     root_id,
     bounding_box=None,
-    bb_is_coordinate=True,
+    bbox_is_coordinate=True,
     compute_partner=True,
     time_stamp = None
 ):
@@ -176,14 +176,14 @@ def get_contact_sites(
     sv_ids = cg.get_subgraph(
         root_id,
         bbox=bounding_box,
-        bbox_is_coordinate=bb_is_coordinate,
+        bbox_is_coordinate=bbox_is_coordinate,
         nodes_only=True,
     )
     # All edges that are _not_ connected / on
     edges, _, areas = cg.get_subgraph_edges(
         root_id,
         bbox=bounding_box,
-        bbox_is_coordinate=bb_is_coordinate,
+        bbox_is_coordinate=bbox_is_coordinate,
         connected_edges=False,
     )
 

--- a/pychunkedgraph/graph/misc.py
+++ b/pychunkedgraph/graph/misc.py
@@ -175,14 +175,14 @@ def get_contact_sites(
     # All supervoxels
     sv_ids = cg.get_subgraph(
         root_id,
-        bounding_box=bounding_box,
+        bbox=bounding_box,
         bb_is_coordinate=bb_is_coordinate,
         nodes_only=True,
     )
     # All edges that are _not_ connected / on
     edges, _, areas = cg.get_subgraph_edges(
         root_id,
-        bounding_box=bounding_box,
+        bbox=bounding_box,
         bb_is_coordinate=bb_is_coordinate,
         connected_edges=False,
     )

--- a/pychunkedgraph/graph/misc.py
+++ b/pychunkedgraph/graph/misc.py
@@ -176,14 +176,14 @@ def get_contact_sites(
     sv_ids = cg.get_subgraph(
         root_id,
         bbox=bounding_box,
-        bb_is_coordinate=bb_is_coordinate,
+        bbox_is_coordinate=bb_is_coordinate,
         nodes_only=True,
     )
     # All edges that are _not_ connected / on
     edges, _, areas = cg.get_subgraph_edges(
         root_id,
         bbox=bounding_box,
-        bb_is_coordinate=bb_is_coordinate,
+        bbox_is_coordinate=bb_is_coordinate,
         connected_edges=False,
     )
 

--- a/pychunkedgraph/meshing/manifest/sharded.py
+++ b/pychunkedgraph/meshing/manifest/sharded.py
@@ -21,7 +21,7 @@ def verified_manifest(
 
     start = time()
     bounding_box = chunk_utils.normalize_bounding_box(
-        cg.meta, bounding_box, bb_is_coordinate=True
+        cg.meta, bounding_box, bbox_is_coordinate=True
     )
     node_ids = get_children_before_start_layer(
         cg, node_id, start_layer, bounding_box=bounding_box
@@ -65,7 +65,7 @@ def speculative_manifest(
 
     start = time()
     bounding_box = chunk_utils.normalize_bounding_box(
-        cg.meta, bounding_box, bb_is_coordinate=True
+        cg.meta, bounding_box, bbox_is_coordinate=True
     )
     node_ids = get_children_before_start_layer(
         cg, node_id, start_layer=start_layer, bounding_box=bounding_box


### PR DESCRIPTION
the bbox vs bounding_box argument names between the two versions is killing us here in keeping these versions synced... I just made the same mistake on master.  