### PR TITLE
Feat: Request nodes and/or leaves of many roots efficiently

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -706,6 +706,36 @@ def handle_leaves(table_id, root_id):
         return atomic_ids
 
 
+### LEAVES OF MANY ROOTS ---------------------------------------------------------------------
+
+
+def handle_leaves_many(table_id):
+    current_app.table_id = table_id
+    user_id = str(g.auth_user["id"])
+    current_app.user_id = user_id
+
+    stop_layer = int(request.args.get("stop_layer", 1))
+    if "bounds" in request.args:
+        bounds = request.args["bounds"]
+        bounding_box = np.array(
+            [b.split("-") for b in bounds.split("_")], dtype=np.int
+        ).T
+    else:
+        bounding_box = None
+
+    node_ids = np.array(json.loads(request.data)["node_ids"], dtype=np.uint64)
+
+    # Call ChunkedGraph
+    cg = app_utils.get_cg(table_id)
+
+    node_to_leaves_mapping = cg.get_subgraph_nodes(
+        node_ids, bounding_box=bounding_box, bb_is_coordinate=True,
+        return_layers=[stop_layer], serializable=True
+    )
+
+    return node_to_leaves_mapping
+
+
 ### LEAVES FROM LEAVES ---------------------------------------------------------
 
 

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -243,7 +243,7 @@ def handle_leaves(table_id, node_id):
 
 ### MANY LEAVES ---------------------------------------------------------------------
 
-
+@bp.route("/table/<table_id>/node/leaves_many", methods=["POST"])
 @bp.route("/table/<table_id>/leaves_many", methods=["POST"])
 @auth_requires_permission("view", public_table_key='table_id', public_node_key='node_id',
                           service_token=AUTH_TOKEN)

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -232,7 +232,6 @@ def handle_l2_chunk_children_binary(table_id, chunk_id):
 
 
 @bp.route("/table/<table_id>/node/<node_id>/leaves", methods=["GET"])
-# @auth_requires_permission("view")
 @auth_requires_permission("view", public_table_key='table_id', public_node_key='node_id',
                           service_token=AUTH_TOKEN)
 def handle_leaves(table_id, node_id):
@@ -240,6 +239,18 @@ def handle_leaves(table_id, node_id):
     leaf_ids = common.handle_leaves(table_id, node_id)
     resp = {"leaf_ids": leaf_ids}
     return jsonify_with_kwargs(resp, int64_as_str=int64_as_str)
+
+
+### MANY LEAVES ---------------------------------------------------------------------
+
+
+@bp.route("/table/<table_id>/leaves_many", methods=["POST"])
+@auth_requires_permission("view", public_table_key='table_id', public_node_key='node_id',
+                          service_token=AUTH_TOKEN)
+def handle_leaves_many(table_id):
+    int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
+    root_to_leaf_dict = common.handle_leaves_many(table_id)
+    return jsonify_with_kwargs(root_to_leaf_dict, int64_as_str=int64_as_str)
 
 
 ### SUBGRAPH -------------------------------------------------------------------

--- a/pychunkedgraph/backend/chunkedgraph.py
+++ b/pychunkedgraph/backend/chunkedgraph.py
@@ -3251,6 +3251,7 @@ class ChunkedGraph(object):
                            bounding_box: Optional[Sequence[Sequence[int]]] = None,
                            bb_is_coordinate: bool = False,
                            return_layers: List[int] = [1],
+                           verbose: bool = False,
                            serializable: bool = False) -> \
             Union[Dict[int, np.ndarray], np.ndarray]:
         """ Return all nodes belonging to the specified agglomeration IDs within
@@ -3272,12 +3273,17 @@ class ChunkedGraph(object):
         if isinstance(agglomeration_id_or_ids, np.uint64) or isinstance(agglomeration_id_or_ids, int):
             single = True
             node_ids = [agglomeration_id_or_ids]
+        if verbose:
+            time_start = time.time()
         layer_nodes_d = self._get_subgraph_multiple_nodes(
             node_ids=node_ids,
             bounding_box=bbox,
             return_layers=return_layers,
             serializable=serializable,
         )
+        if verbose:
+            self.logger.debug("Took %.3fms to retrieve subgraph(s) of %d node(s)" %
+                              ((time.time() - time_start) * 1000, len(node_ids)))
         if single:
             if serializable:
                 return layer_nodes_d[str(agglomeration_id_or_ids)]

--- a/pychunkedgraph/backend/chunkedgraph.py
+++ b/pychunkedgraph/backend/chunkedgraph.py
@@ -18,7 +18,7 @@ from pychunkedgraph.backend.chunkedgraph_utils import compute_indices_pandas, \
     compute_bitmasks, get_google_compatible_time_stamp, \
     get_time_range_filter, get_time_range_and_column_filter, get_max_time, \
     combine_cross_chunk_edge_dicts, get_min_time, partial_row_data_to_column_dict
-from pychunkedgraph.backend.utils import serializers, column_keys, row_keys, basetypes
+from pychunkedgraph.backend.utils import serializers, column_keys, row_keys, basetypes, misc_utils
 from pychunkedgraph.backend import chunkedgraph_exceptions as cg_exceptions, \
     chunkedgraph_edits as cg_edits, ChunkedGraphMeta
 from pychunkedgraph.backend.graphoperation import (
@@ -3100,88 +3100,80 @@ class ChunkedGraph(object):
         if bounding_box is None:
             return None
 
+        bbox = bounding_box.copy()
         if bb_is_coordinate:
-            bounding_box[0] = self.get_chunk_coordinates_from_vol_coordinates(
-                bounding_box[0][0], bounding_box[0][1], bounding_box[0][2],
+            bbox[0] = self.get_chunk_coordinates_from_vol_coordinates(
+                bbox[0][0], bbox[0][1], bbox[0][2],
                 resolution=self.cv.resolution, ceil=False)
-            bounding_box[1] = self.get_chunk_coordinates_from_vol_coordinates(
-                bounding_box[1][0], bounding_box[1][1], bounding_box[1][2],
+            bbox[1] = self.get_chunk_coordinates_from_vol_coordinates(
+                bbox[1][0], bbox[1][1], bbox[1][2],
                 resolution=self.cv.resolution, ceil=True)
-            return bounding_box
+            return bbox
         else:
-            return np.array(bounding_box, dtype=np.int)
+            return np.array(bbox, dtype=np.int)
 
-    def _get_subgraph_higher_layer_nodes(
-            self, node_id: np.uint64,
+    def _get_subgraph_multiple_nodes(
+            self, node_ids: Iterable[np.uint64],
             bounding_box: Optional[Sequence[Sequence[int]]],
             return_layers: Sequence[int],
-            verbose: bool):
+            serializable: bool):
 
-        def _get_subgraph_higher_layer_nodes_threaded(
-                node_ids: Iterable[np.uint64]) -> List[np.uint64]:
-            children = self.get_children(node_ids, flatten=True)
+        assert len(return_layers) > 0
+        from collections import ChainMap
 
-            if len(children) > 0 and bounding_box is not None:
-                chunk_coordinates = np.array([self.get_chunk_coordinates(c) for c in children])
-                child_layers = self.get_chunk_layers(children)
-                adapt_child_layers = child_layers - 2
-                adapt_child_layers[adapt_child_layers < 0] = 0
+        def _get_dict_key(raw_key):
+            if serializable:
+                return str(raw_key)
+            return raw_key
 
-                bounding_box_layer = bounding_box[None] / \
-                                     (self.fan_out ** adapt_child_layers)[:, None, None]
-
-                bound_check = np.array([
-                    np.all(chunk_coordinates < bounding_box_layer[:, 1], axis=1),
-                    np.all(chunk_coordinates + 1 > bounding_box_layer[:, 0], axis=1)]).T
-
-                bound_check_mask = np.all(bound_check, axis=1)
-                children = children[bound_check_mask]
-
+        def _get_subgraph_multiple_nodes_threaded(
+            node_ids_batch: Iterable[np.uint64],
+        ) -> List[np.uint64]:
+            children = self.get_children(np.sort(node_ids_batch))
+            if bounding_box is not None:
+                filtered_children = {}
+                for node_id, nodes_children in children.items():
+                    if self.get_chunk_layer(node_id) == 2:
+                        # All children will be in same chunk so no need to check
+                        filtered_children[_get_dict_key(node_id)] = nodes_children
+                    else:
+                        bound_check_mask = self.mask_nodes_by_bounding_box(
+                            nodes_children, bounding_box
+                        )
+                        filtered_children[_get_dict_key(node_id)] = nodes_children[
+                            bound_check_mask
+                        ]
+                return filtered_children
             return children
 
-        if bounding_box is not None:
-            bounding_box = np.array(bounding_box)
+        subgraph_progress = misc_utils.SubgraphProgress(
+            self, node_ids, return_layers, serializable
+        )
 
-        layer = self.get_chunk_layer(node_id)
-        assert layer > 1
+        while not subgraph_progress.done_processing():
+            this_n_threads = np.min(
+                [int(len(subgraph_progress.cur_nodes) // 50000) + 1, mu.n_cpus]
+            )
+            cur_nodes_child_maps = mu.multithread_func(
+                _get_subgraph_multiple_nodes_threaded,
+                np.array_split(subgraph_progress.cur_nodes, this_n_threads),
+                n_threads=this_n_threads,
+                debug=this_n_threads == 1,
+            )
+            cur_nodes_children = dict(ChainMap(*cur_nodes_child_maps))
+            subgraph_progress.process_batch_of_children(cur_nodes_children)
 
-        nodes_per_layer = {}
-        child_ids = np.array([node_id], dtype=np.uint64)
-        stop_layer = max(2, np.min(return_layers))
+        if len(return_layers) == 1:
+            for node_id in node_ids:
+                subgraph_progress.node_to_subgraph[
+                    _get_dict_key(node_id)
+                ] = subgraph_progress.node_to_subgraph[
+                    _get_dict_key(node_id)
+                ][
+                    return_layers[0]
+                ]
 
-        if layer in return_layers:
-            nodes_per_layer[layer] = child_ids
-
-        if verbose:
-            time_start = time.time()
-
-        while layer > stop_layer:
-            # Use heuristic to guess the optimal number of threads
-            child_id_layers = self.get_chunk_layers(child_ids)
-            this_layer_m = child_id_layers == layer
-            this_layer_child_ids = child_ids[this_layer_m]
-            next_layer_child_ids = child_ids[~this_layer_m]
-
-            n_child_ids = len(child_ids)
-            this_n_threads = np.min([int(n_child_ids // 50000) + 1, mu.n_cpus])
-
-            child_ids = np.fromiter(chain.from_iterable(mu.multithread_func(
-                _get_subgraph_higher_layer_nodes_threaded,
-                np.array_split(this_layer_child_ids, this_n_threads),
-                n_threads=this_n_threads, debug=this_n_threads == 1)), np.uint64)
-            child_ids = np.concatenate([child_ids, next_layer_child_ids])
-
-            if verbose:
-                self.logger.debug("Layer %d: %.3fms for %d children with %d threads" %
-                                  (layer, (time.time() - time_start) * 1000, n_child_ids,
-                                   this_n_threads))
-                time_start = time.time()
-
-            layer -= 1
-            if layer in return_layers:
-                nodes_per_layer[layer] = child_ids
-
-        return nodes_per_layer
+        return subgraph_progress.node_to_subgraph
 
     def get_subgraph_edges(self, agglomeration_id: np.uint64,
                            bounding_box: Optional[Sequence[Sequence[int]]] = None,
@@ -3211,9 +3203,12 @@ class ChunkedGraph(object):
         bounding_box = self.normalize_bounding_box(bounding_box, bb_is_coordinate)
 
         # Layer 3+
-        child_ids = self._get_subgraph_higher_layer_nodes(
-            node_id=agglomeration_id, bounding_box=bounding_box,
-            return_layers=[2], verbose=verbose)[2]
+        child_ids = self._get_subgraph_multiple_nodes(
+            node_ids=[agglomeration_id],
+            bounding_box=bounding_box,
+            return_layers=[2],
+            serializable=False
+        )[agglomeration_id]
 
         # Layer 2
         if verbose:
@@ -3253,16 +3248,16 @@ class ChunkedGraph(object):
 
         return edges, affinities, areas
 
-    def get_subgraph_nodes(self, agglomeration_id: np.uint64,
+    def get_subgraph_nodes(self, agglomeration_id_or_ids: Union[np.uint64, Iterable[np.uint64]],
                            bounding_box: Optional[Sequence[Sequence[int]]] = None,
                            bb_is_coordinate: bool = False,
                            return_layers: List[int] = [1],
-                           verbose: bool = True) -> \
+                           serializable: bool = False) -> \
             Union[Dict[int, np.ndarray], np.ndarray]:
-        """ Return all nodes belonging to the specified agglomeration ID within
+        """ Return all nodes belonging to the specified agglomeration IDs within
             the defined bounding box and requested layers.
 
-        :param agglomeration_id: np.uint64
+        :param agglomeration_id_or_ids: Union[np.uint64, Iterable[np.uint64]] 
         :param bounding_box: [[x_l, y_l, z_l], [x_h, y_h, z_h]]
         :param bb_is_coordinate: bool
         :param return_layers: List[int]
@@ -3271,52 +3266,25 @@ class ChunkedGraph(object):
                  Dict[int, np.array] if multiple layers are requested
         """
 
-        def _get_subgraph_layer2_nodes(node_ids: Iterable[np.uint64]) -> np.ndarray:
-            return self.get_children(node_ids, flatten=True)
-
-        stop_layer = np.min(return_layers)
-        bounding_box = self.normalize_bounding_box(bounding_box,
-                                                   bb_is_coordinate)
-
-        # Layer 3+
-        if stop_layer >= 2:
-            nodes_per_layer = self._get_subgraph_higher_layer_nodes(
-                node_id=agglomeration_id, bounding_box=bounding_box,
-                return_layers=return_layers, verbose=verbose)
-        else:
-            # Need to retrieve layer 2 even if the user doesn't require it
-            nodes_per_layer = self._get_subgraph_higher_layer_nodes(
-                node_id=agglomeration_id, bounding_box=bounding_box,
-                return_layers=return_layers+[2], verbose=verbose)
-
-            # Layer 2
-            if verbose:
-                time_start = time.time()
-
-            child_ids = nodes_per_layer[2]
-            if 2 not in return_layers:
-                del nodes_per_layer[2]
-
-            # Use heuristic to guess the optimal number of threads
-            n_child_ids = len(child_ids)
-            this_n_threads = np.min([int(n_child_ids // 50000) + 1, mu.n_cpus])
-
-            child_ids = np.fromiter(chain.from_iterable(mu.multithread_func(
-                _get_subgraph_layer2_nodes,
-                np.array_split(child_ids, this_n_threads),
-                n_threads=this_n_threads, debug=this_n_threads == 1)), dtype=np.uint64)
-
-            if verbose:
-                self.logger.debug("Layer 2: %.3fms for %d children with %d threads" %
-                                  ((time.time() - time_start) * 1000, n_child_ids,
-                                   this_n_threads))
-
-            nodes_per_layer[1] = child_ids
-
-        if len(nodes_per_layer) == 1:
-            return list(nodes_per_layer.values())[0]
-        else:
-            return nodes_per_layer
+        """Get the children of the specified node_ids that are at each of the specified
+        return_layers within the specified bounding box."""
+        single = False
+        node_ids = agglomeration_id_or_ids
+        bbox = self.normalize_bounding_box(bounding_box, bb_is_coordinate)
+        if isinstance(agglomeration_id_or_ids, np.uint64) or isinstance(agglomeration_id_or_ids, int):
+            single = True
+            node_ids = [agglomeration_id_or_ids]
+        layer_nodes_d = self._get_subgraph_multiple_nodes(
+            node_ids=node_ids,
+            bounding_box=bbox,
+            return_layers=return_layers,
+            serializable=serializable,
+        )
+        if single:
+            if serializable:
+                return layer_nodes_d[str(agglomeration_id_or_ids)]
+            return layer_nodes_d[agglomeration_id_or_ids]
+        return layer_nodes_d
 
     def flatten_row_dict(self, row_dict: Dict[column_keys._Column,
                                               List[bigtable.row_data.Cell]]) -> Dict:
@@ -3924,3 +3892,29 @@ class ChunkedGraph(object):
         if not children:
             return []
         return [children[x][0].timestamp for x in node_ids]
+
+    def mask_nodes_by_bounding_box(
+        self,
+        nodes: Union[Iterable[np.uint64], np.uint64],
+        bounding_box: Optional[Sequence[Sequence[int]]] = None,
+    ) -> Iterable[np.bool]:
+        if bounding_box is None:
+            return np.ones(len(nodes), np.bool)
+        else:
+            chunk_coordinates = np.array(
+                [self.get_chunk_coordinates(c) for c in nodes]
+            )
+            layers = self.get_chunk_layers(nodes)
+            adapt_layers = layers - 2
+            adapt_layers[adapt_layers < 0] = 0
+            bounding_box_layer = (
+                bounding_box[None] / (self.fan_out ** adapt_layers)[:, None, None]
+            )
+            bound_check = np.array(
+                [
+                    np.all(chunk_coordinates < bounding_box_layer[:, 1], axis=1),
+                    np.all(chunk_coordinates + 1 > bounding_box_layer[:, 0], axis=1),
+                ]
+            ).T
+
+            return np.all(bound_check, axis=1)

--- a/pychunkedgraph/backend/chunkedgraph.py
+++ b/pychunkedgraph/backend/chunkedgraph.py
@@ -3100,7 +3100,7 @@ class ChunkedGraph(object):
         if bounding_box is None:
             return None
 
-        bbox = bounding_box.copy()
+        bbox = np.array(bounding_box, dtype=np.int)
         if bb_is_coordinate:
             bbox[0] = self.get_chunk_coordinates_from_vol_coordinates(
                 bbox[0][0], bbox[0][1], bbox[0][2],
@@ -3109,8 +3109,7 @@ class ChunkedGraph(object):
                 bbox[1][0], bbox[1][1], bbox[1][2],
                 resolution=self.cv.resolution, ceil=True)
             return bbox
-        else:
-            return np.array(bbox, dtype=np.int)
+        return bbox
 
     def _get_subgraph_multiple_nodes(
             self, node_ids: Iterable[np.uint64],
@@ -3256,7 +3255,6 @@ class ChunkedGraph(object):
             Union[Dict[int, np.ndarray], np.ndarray]:
         """ Return all nodes belonging to the specified agglomeration IDs within
             the defined bounding box and requested layers.
-
         :param agglomeration_id_or_ids: Union[np.uint64, Iterable[np.uint64]] 
         :param bounding_box: [[x_l, y_l, z_l], [x_h, y_h, z_h]]
         :param bb_is_coordinate: bool

--- a/pychunkedgraph/backend/chunkedgraph_utils.py
+++ b/pychunkedgraph/backend/chunkedgraph_utils.py
@@ -8,7 +8,7 @@ from google.cloud import bigtable
 from google.cloud.bigtable.row_filters import TimestampRange, \
     TimestampRangeFilter, ColumnRangeFilter, RowFilterChain, \
     RowFilterUnion, RowFilter
-from pychunkedgraph.backend.utils import column_keys, serializers
+from pychunkedgraph.backend.utils import basetypes, column_keys, serializers
 
 
 def compute_indices_pandas(data) -> pd.Series:

--- a/pychunkedgraph/backend/utils/misc_utils.py
+++ b/pychunkedgraph/backend/utils/misc_utils.py
@@ -1,0 +1,105 @@
+import numpy as np
+from . import basetypes
+
+
+class SubgraphProgress:
+    """
+    Helper class to keep track of node relationships
+    while calling cg.get_subgraph(node_ids)
+    """
+
+    def __init__(self, cg, node_ids, return_layers, serializable):
+        self.node_ids = node_ids
+        self.return_layers = return_layers
+        self.cg = cg
+        self.serializable = serializable
+
+        self.node_to_subgraph = {}
+        # "Frontier" of nodes that cg.get_children will be called on
+        self.cur_nodes = np.array(list(node_ids), dtype=np.uint64)
+        # Mapping of current frontier to self.node_ids
+        self.cur_nodes_to_original_nodes = dict(
+            zip(self.cur_nodes, self.cur_nodes)
+        )
+        self.stop_layer = max(1, np.min(return_layers))
+        self.create_initial_node_to_subgraph()
+
+    def done_processing(self):
+        return self.cur_nodes is None or len(self.cur_nodes) == 0
+
+    def create_initial_node_to_subgraph(self):
+        """
+        Create initial subgraph. We will incrementally populate after processing
+        each batch of children, and return it when there are no more to process.
+        """
+        for node_id in self.cur_nodes:
+            node_key = self.get_dict_key(node_id)
+            self.node_to_subgraph[node_key] = {}
+            for return_layer in self.return_layers:
+                self.node_to_subgraph[node_key][return_layer] = []
+            node_layer = self.cg.get_chunk_layer(node_id)
+            if node_layer in self.return_layers:
+                self.node_to_subgraph[node_key][node_layer].append([node_id])
+
+    def get_dict_key(self, node_id):
+        if self.serializable:
+            return str(node_id)
+        return node_id
+
+    def process_batch_of_children(self, cur_nodes_children):
+        """
+        Given children of self.cur_nodes, update subgraph and
+        produce next frontier (if any).
+        """
+        next_nodes_to_process = []
+        next_nodes_to_original_nodes_keys = []
+        next_nodes_to_original_nodes_values = []
+        for cur_node, children in cur_nodes_children.items():
+            children_layers = self.cg.get_chunk_layers(children)
+            continue_mask = children_layers > self.stop_layer
+            continue_children = children[continue_mask]
+            original_id = self.cur_nodes_to_original_nodes[np.uint64(cur_node)]
+            if len(continue_children) > 0:
+                # These nodes will be in next frontier
+                next_nodes_to_process.append(continue_children)
+                next_nodes_to_original_nodes_keys.append(continue_children)
+                next_nodes_to_original_nodes_values.append(
+                    [original_id] * len(continue_children)
+                )
+            for return_layer in self.return_layers:
+                # Update subgraph for each return_layer
+                children_at_layer = children[children_layers == return_layer]
+                if len(children_at_layer) > 0:
+                    self.node_to_subgraph[self.get_dict_key(original_id)][
+                        return_layer
+                    ].append(children_at_layer)
+
+        if len(next_nodes_to_process) == 0:
+            self.cur_nodes = None
+            # We are done, so we can concatenate/flatten each entry in node_to_subgraph
+            self.flatten_subgraph()
+        else:
+            self.cur_nodes = np.concatenate(next_nodes_to_process)
+            self.cur_nodes_to_original_nodes = dict(
+                zip(
+                    np.concatenate(next_nodes_to_original_nodes_keys),
+                    np.concatenate(next_nodes_to_original_nodes_values),
+                )
+            )
+
+    def flatten_subgraph(self):
+        # Flatten each entry in node_to_subgraph before returning
+        for node_id in self.node_ids:
+            for return_layer in self.return_layers:
+                node_key = self.get_dict_key(node_id)
+                children_at_layer = self.node_to_subgraph[node_key][
+                    return_layer
+                ]
+                if len(children_at_layer) > 0:
+                    self.node_to_subgraph[node_key][
+                        return_layer
+                    ] = np.concatenate(children_at_layer)
+                else:
+                    self.node_to_subgraph[node_key][return_layer] = np.empty(
+                        0, dtype=basetypes.NODE_ID
+                    )

--- a/pychunkedgraph/tests/test_uncategorized.py
+++ b/pychunkedgraph/tests/test_uncategorized.py
@@ -2223,8 +2223,8 @@ class TestGraphMergeSplit:
             u_root_ids = np.unique(root_ids)
             these_child_ids = []
             for root_id in u_root_ids:
-                these_child_ids.extend(cgraph.get_subgraph_nodes(root_id, verbose=False))
-                cgraph.logger.debug((root_id, cgraph.get_subgraph_nodes(root_id, verbose=False)))
+                these_child_ids.extend(cgraph.get_subgraph_nodes(root_id))
+                cgraph.logger.debug((root_id, cgraph.get_subgraph_nodes(root_id)))
 
             assert len(these_child_ids) == 4
             assert len(u_root_ids) == 2

--- a/pychunkedgraph/tests/test_uncategorized.py
+++ b/pychunkedgraph/tests/test_uncategorized.py
@@ -704,9 +704,9 @@ class TestGraphSimpleQueries:
 
         lvl3_nodes_1 = cgraph.get_subgraph_nodes(root1, return_layers=[3])
         lvl3_nodes_2 = cgraph.get_subgraph_nodes(root2, return_layers=[3])
-        assert len(lvl3_nodes_1) == 1
+        assert len(lvl3_nodes_1) == 0
         assert len(lvl3_nodes_2) == 2
-        assert to_label(cgraph, 2, 0, 0, 0, 1) in lvl3_nodes_1
+        assert not to_label(cgraph, 2, 0, 0, 0, 1) in lvl3_nodes_1
         assert to_label(cgraph, 3, 0, 0, 0, 1) in lvl3_nodes_2
         assert to_label(cgraph, 3, 1, 0, 0, 1) in lvl3_nodes_2
 
@@ -1412,7 +1412,10 @@ class TestGraphMerge:
 
         for layer in n_cross_edges_layer.keys():
             cgraph.logger.debug("LAYER %d" % layer)
-            assert len(np.unique(n_cross_edges_layer[layer])) == 1
+            if layer == 5:
+                assert len(np.unique(n_cross_edges_layer[layer])) == 2
+            else:
+                assert len(np.unique(n_cross_edges_layer[layer])) == 1
 
 
 class TestGraphSplit:

--- a/pychunkedgraph/tests/test_uncategorized.py
+++ b/pychunkedgraph/tests/test_uncategorized.py
@@ -1412,7 +1412,8 @@ class TestGraphMerge:
 
         for layer in n_cross_edges_layer.keys():
             cgraph.logger.debug("LAYER %d" % layer)
-            if layer == 5:
+            # Second to last layer has an additional unique number of cross chunk edges
+            if layer == cgraph.n_layers - 1:
                 assert len(np.unique(n_cross_edges_layer[layer])) == 2
             else:
                 assert len(np.unique(n_cross_edges_layer[layer])) == 1


### PR DESCRIPTION
This functionality already exists in v2, here I've ported it to v1 (see: https://github.com/seung-lab/PyChunkedGraph/pull/228)
Add endpoint leaves_many that takes many node_ids and returns a dictionary of nodes to leaves to the user. Add new function `_get_subgraph_multiple_nodes` which replaces `_get_subgraph_higher_layer_nodes` and can take more than one node_id -- the advantage is that the leaves of the requested nodes can be requested at the same time, instead of calling the function multiple times. This means we can receive a big performance boost when retrieving leaves of multiple nodes, since we only have to make roughly` n_layers` requests to BigTable instead of `n_layers * n_nodes`. Right now the ChunkedGraph does not request leaves of multiple roots, but one clear applicable area is using Neuroglancer to view ChunkedGraph data.

I had to change a couple of the unit tests. `_get_subgraph_higher_layer_nodes`  had a bug where it did not properly take into account skip connections, so say `cg.get_subgraph_nodes(node_id, return_layers=[3])` could return node_ids with layer 2. The two unit tests I changed relied on this incorrect behavior so with that bug fixed I've changed them.