### PR TITLE
active/inactive edge

### DIFF
--- a/pychunkedgraph/graph/chunkedgraph.py
+++ b/pychunkedgraph/graph/chunkedgraph.py
@@ -618,9 +618,7 @@ class ChunkedGraph:
             supervoxels = self.get_children(level2_ids, flatten=True)
             mask0 = np.in1d(all_chunk_edges[:, 0], supervoxels)
             mask1 = np.in1d(all_chunk_edges[:, 1], supervoxels)
-            mask2 = np.in1d(all_chunk_edges[:, 1], supervoxels)
-            mask3 = np.in1d(all_chunk_edges[:, 0], supervoxels)
-            return all_chunk_edges[mask0 & mask1 | mask2 & mask3]
+            return all_chunk_edges[mask0 | mask1]
 
         with TimeIt(f"categorize_edges"):
             l2id_children_d = self.get_children(level2_ids)

--- a/pychunkedgraph/graph/chunkedgraph.py
+++ b/pychunkedgraph/graph/chunkedgraph.py
@@ -618,7 +618,7 @@ class ChunkedGraph:
             supervoxels = self.get_children(level2_ids, flatten=True)
             mask0 = np.in1d(all_chunk_edges[:, 0], supervoxels)
             mask1 = np.in1d(all_chunk_edges[:, 1], supervoxels)
-            return all_chunk_edges[mask0 | mask1]
+            return all_chunk_edges[mask0 & mask1]
 
         with TimeIt(f"categorize_edges"):
             l2id_children_d = self.get_children(level2_ids)


### PR DESCRIPTION
* changes how active/inactive status of an edge is determined, using lowest common parent instead of root reflects the topology more accurately
* also fixes redundant use of masks in `get_l2_agglomerations`