### PR TITLE
Improved supervoxel lookup

### DIFF
--- a/pychunkedgraph/app/app_utils.py
+++ b/pychunkedgraph/app/app_utils.py
@@ -11,6 +11,22 @@ from google.cloud import bigtable, datastore
 from pychunkedgraph.backend import chunkedgraph
 from pychunkedgraph.logging import flask_log_db, jsonformatter
 
+import networkx as nx
+from scipy import spatial
+
+
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    NamedTuple,
+)
+
 CACHE = {}
 
 

--- a/pychunkedgraph/app/app_utils.py
+++ b/pychunkedgraph/app/app_utils.py
@@ -9,6 +9,7 @@ from google.auth import default as default_creds
 from google.cloud import bigtable, datastore
 
 from pychunkedgraph.backend import chunkedgraph
+from pychunkedgraph.backend import chunkedgraph_exceptions as cg_exceptions
 from pychunkedgraph.logging import flask_log_db, jsonformatter
 
 import networkx as nx

--- a/pychunkedgraph/app/app_utils.py
+++ b/pychunkedgraph/app/app_utils.py
@@ -28,7 +28,9 @@ def jsonify_with_kwargs(data, as_response=True, **kwargs):
 
     resp = json.dumps(data, **kwargs)
     if as_response:
-        return current_app.response_class(resp + "\n", mimetype=current_app.config["JSONIFY_MIMETYPE"])
+        return current_app.response_class(
+            resp + "\n", mimetype=current_app.config["JSONIFY_MIMETYPE"]
+        )
     else:
         return resp
 
@@ -103,17 +105,18 @@ def get_cg(table_id):
 def get_log_db(table_id):
     if "log_db" not in CACHE:
         client = get_datastore_client(current_app.config)
-        CACHE["log_db"] = flask_log_db.FlaskLogDatabase(table_id, client=client,
-                                                        credentials=credentials)
+        CACHE["log_db"] = flask_log_db.FlaskLogDatabase(
+            table_id, client=client, credentials=credentials
+        )
 
     return CACHE["log_db"]
 
 
 def toboolean(value):
-    """ Transform value to boolean type.
-        :param value: bool/int/str
-        :return: bool
-        :raises: ValueError, if value is not boolean.
+    """Transform value to boolean type.
+    :param value: bool/int/str
+    :return: bool
+    :raises: ValueError, if value is not boolean.
     """
     if not value:
         raise ValueError("Can't convert null to boolean")
@@ -134,7 +137,7 @@ def toboolean(value):
 
 
 def tobinary(ids):
-    """ Transform id(s) to binary format
+    """Transform id(s) to binary format
 
     :param ids: uint64 or list of uint64s
     :return: binary
@@ -143,9 +146,60 @@ def tobinary(ids):
 
 
 def tobinary_multiples(arr):
-    """ Transform id(s) to binary format
+    """Transform id(s) to binary format
 
     :param arr: list of uint64 or list of uint64s
     :return: binary
     """
     return [np.array(arr_i).tobytes() for arr_i in arr]
+
+
+def handle_supervoxel_id_lookup(
+    cg, coordinates: Sequence[Sequence[int]], node_ids: Sequence[np.uint64]
+) -> Sequence[np.uint64]:
+    """Helper to lookup supervoxel ids.
+
+    This takes care of grouping coordinates."""
+
+    def ccs(coordinates_nm_):
+        graph = nx.Graph()
+
+        dist_mat = spatial.distance.cdist(coordinates_nm_, coordinates_nm_)
+        for edge in np.array(np.where(dist_mat < 1000)).T:
+            graph.add_edge(*edge)
+
+        ccs = [np.array(list(cc)) for cc in nx.connected_components(graph)]
+        return ccs
+
+    coordinates = np.array(coordinates, dtype=np.int)
+    coordinates_nm = coordinates * cg.cv.resolution
+
+    node_ids = np.array(node_ids, dtype=np.uint64)
+
+    if len(coordinates.shape) != 2:
+        raise cg_exceptions.BadRequest(
+            f"Could not determine supervoxel ID for coordinates "
+            f"{coordinates} - Validation stage."
+        )
+
+    atomic_ids = np.zeros(len(coordinates), dtype=np.uint64)
+    for node_id in np.unique(node_ids):
+        node_id_m = node_ids == node_id
+
+        for cc in ccs(coordinates_nm[node_id_m]):
+            m_ids = np.where(node_id_m)[0][cc]
+
+            for max_dist_nm in [75, 150, 250, 500]:
+                atomic_ids_sub = cg.get_atomic_ids_from_coords(
+                    coordinates[m_ids], parent_id=node_id, max_dist_nm=max_dist_nm
+                )
+                if atomic_ids_sub is not None:
+                    break
+            if atomic_ids_sub is None:
+                raise cg_exceptions.BadRequest(
+                    f"Could not determine supervoxel ID for coordinates "
+                    f"{coordinates} - Validation stage."
+                )
+
+            atomic_ids[m_ids] = atomic_ids_sub
+    return atomic_ids

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -195,7 +195,7 @@ def handle_api_versions():
 
 ### HELPERS -------------------------------------------------------------------
 def handle_supervoxel_id_lookup(cg, coordinates, node_ids):
-    coordinates = np.array(coordinates)
+    coordinates = np.array(coordinates, dtype=np.int)
     node_ids = np.array(node_ids, dtype=np.uint64)
     
     if len(coordinates.shape) != 2:

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -201,7 +201,13 @@ def handle_api_versions():
 
 
 ### HELPERS -------------------------------------------------------------------
-def handle_supervoxel_id_lookup(cg, coordinates, node_ids):
+def handle_supervoxel_id_lookup(
+    cg, coordinates: Sequence[Sequence[int]], node_ids: Sequence[np.uint64]
+) -> Sequence[np.uint64]:
+    """Helper to lookup supervoxel ids.
+
+    This takes care of grouping coordinates."""
+
     def ccs(coordinates_nm_):
         graph = nx.Graph()
 
@@ -764,8 +770,11 @@ def handle_leaves_many(table_id):
     cg = app_utils.get_cg(table_id)
 
     node_to_leaves_mapping = cg.get_subgraph_nodes(
-        node_ids, bounding_box=bounding_box, bb_is_coordinate=True,
-        return_layers=[stop_layer], serializable=True
+        node_ids,
+        bounding_box=bounding_box,
+        bb_is_coordinate=True,
+        return_layers=[stop_layer],
+        serializable=True,
     )
 
     return node_to_leaves_mapping

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -29,7 +29,8 @@ from pychunkedgraph.graph_analysis import analysis, contact_sites
 from pychunkedgraph.backend.graphoperation import GraphEditOperation
 
 __api_versions__ = [0, 1]
-__segmentation_url_prefix__ = os.environ.get('SEGMENTATION_URL_PREFIX', 'segmentation')
+__segmentation_url_prefix__ = os.environ.get("SEGMENTATION_URL_PREFIX", "segmentation")
+
 
 def index():
     return f"PyChunkedGraph Segmentation v{__version__}"
@@ -57,7 +58,7 @@ def before_request():
     current_app.table_id = None
     current_app.request_type = None
 
-    content_encoding = request.headers.get('Content-Encoding', '')
+    content_encoding = request.headers.get("Content-Encoding", "")
 
     if "gzip" in content_encoding.lower():
         request.data = compression.decompress(request.data, "gzip")
@@ -86,26 +87,29 @@ def after_request(response):
                 request_type=current_app.request_type,
             )
     except Exception as e:
-        current_app.logger.debug(f"{current_app.user_id}: LogDB entry not"
-                                 f" successful: {e}")
+        current_app.logger.debug(
+            f"{current_app.user_id}: LogDB entry not" f" successful: {e}"
+        )
 
-    accept_encoding = request.headers.get('Accept-Encoding', '')
+    accept_encoding = request.headers.get("Accept-Encoding", "")
 
-    if 'gzip' not in accept_encoding.lower():
+    if "gzip" not in accept_encoding.lower():
         return response
 
     response.direct_passthrough = False
 
-    if (response.status_code < 200 or
-            response.status_code >= 300 or
-            'Content-Encoding' in response.headers):
+    if (
+        response.status_code < 200
+        or response.status_code >= 300
+        or "Content-Encoding" in response.headers
+    ):
         return response
 
     response.data = compression.gzip_compress(response.data)
 
-    response.headers['Content-Encoding'] = 'gzip'
-    response.headers['Vary'] = 'Accept-Encoding'
-    response.headers['Content-Length'] = len(response.data)
+    response.headers["Content-Encoding"] = "gzip"
+    response.headers["Vary"] = "Accept-Encoding"
+    response.headers["Content-Length"] = len(response.data)
 
     return response
 
@@ -195,6 +199,7 @@ def handle_info(table_id):
 def handle_api_versions():
     return jsonify(__api_versions__)
 
+
 ### HELPERS -------------------------------------------------------------------
 def handle_supervoxel_id_lookup(cg, coordinates, node_ids):
     def ccs(coordinates_nm_):
@@ -206,35 +211,37 @@ def handle_supervoxel_id_lookup(cg, coordinates, node_ids):
 
         ccs = [np.array(list(cc)) for cc in nx.connected_components(graph)]
         return ccs
-            
+
     coordinates = np.array(coordinates, dtype=np.int)
     coordinates_nm = coordinates * cg.cv.resolution
-    
+
     node_ids = np.array(node_ids, dtype=np.uint64)
-    
+
     if len(coordinates.shape) != 2:
         raise cg_exceptions.BadRequest(
             f"Could not determine supervoxel ID for coordinates "
-            f"{coordinates} - Validation stage.")
-    
-    atomic_ids = np.zeros(len(coordinates), dtype=np.uint64)    
+            f"{coordinates} - Validation stage."
+        )
+
+    atomic_ids = np.zeros(len(coordinates), dtype=np.uint64)
     for node_id in np.unique(node_ids):
         node_id_m = node_ids == node_id
-        
+
         for cc in ccs(coordinates_nm[node_id_m]):
-            m_ids = np.where(node_id_m)[0][cc]            
-            
+            m_ids = np.where(node_id_m)[0][cc]
+
             for max_dist_nm in [75, 150, 250, 500]:
                 print(coordinates[m_ids], node_id)
-                atomic_ids_sub = cg.get_atomic_ids_from_coords(coordinates[m_ids], 
-                                                               parent_id=node_id,
-                                                               max_dist_nm=max_dist_nm)
+                atomic_ids_sub = cg.get_atomic_ids_from_coords(
+                    coordinates[m_ids], parent_id=node_id, max_dist_nm=max_dist_nm
+                )
                 if atomic_ids_sub is not None:
                     break
             if atomic_ids_sub is None:
                 raise cg_exceptions.BadRequest(
                     f"Could not determine supervoxel ID for coordinates "
-                    f"{coordinates} - Validation stage.")
+                    f"{coordinates} - Validation stage."
+                )
 
             atomic_ids[m_ids] = atomic_ids_sub
     return atomic_ids
@@ -265,16 +272,13 @@ def handle_root(table_id, atomic_id):
         try:
             stop_layer = int(stop_layer)
         except (TypeError, ValueError):
-            raise (
-                cg_exceptions.BadRequest(
-                    "stop_layer is not an integer"
-                )
-            )
+            raise (cg_exceptions.BadRequest("stop_layer is not an integer"))
 
     # Call ChunkedGraph
     cg = app_utils.get_cg(table_id)
-    root_id = cg.get_root(np.uint64(atomic_id), stop_layer=stop_layer,
-                          time_stamp=timestamp)
+    root_id = cg.get_root(
+        np.uint64(atomic_id), stop_layer=stop_layer, time_stamp=timestamp
+    )
 
     # Return root ID
     return root_id
@@ -290,8 +294,7 @@ def handle_roots(table_id, is_binary=False):
     if is_binary:
         node_ids = np.frombuffer(request.data, np.uint64)
     else:
-        node_ids = np.array(json.loads(request.data)["node_ids"],
-                            dtype=np.uint64)
+        node_ids = np.array(json.loads(request.data)["node_ids"], dtype=np.uint64)
     # Convert seconds since epoch to UTC datetime
     try:
         timestamp = float(request.args.get("timestamp", time.time()))
@@ -309,9 +312,9 @@ def handle_roots(table_id, is_binary=False):
     assert_roots = bool(request.args.get("assert_roots", False))
     # Call ChunkedGraph
     cg = app_utils.get_cg(table_id)
-    root_ids = cg.get_roots(node_ids, stop_layer=stop_layer,
-                            time_stamp=timestamp,
-                            assert_roots=assert_roots)
+    root_ids = cg.get_roots(
+        node_ids, stop_layer=stop_layer, time_stamp=timestamp, assert_roots=assert_roots
+    )
 
     return root_ids
 
@@ -341,12 +344,14 @@ def handle_l2_chunk_children(table_id, chunk_id, as_array):
     if chunk_layer != 2:
         raise (
             cg_exceptions.PreconditionError(
-                f'This function only accepts level 2 chunks, the chunk requested is a level {chunk_layer} chunk'
+                f"This function only accepts level 2 chunks, the chunk requested is a level {chunk_layer} chunk"
             )
         )
 
     rr_chunk = cg.range_read_chunk(
-        chunk_id=np.uint64(chunk_id), columns=column_keys.Hierarchy.Child, time_stamp=timestamp
+        chunk_id=np.uint64(chunk_id),
+        columns=column_keys.Hierarchy.Child,
+        time_stamp=timestamp,
     )
 
     if as_array:
@@ -366,17 +371,21 @@ def handle_l2_chunk_children(table_id, chunk_id, as_array):
 
         return l2_chunk_dict
 
+
 def str2bool(v):
     return v.lower() in ("yes", "true", "t", "1")
 
+
 def trigger_remesh(table_id, new_lvl2_ids, is_priority=True):
     auth_header = {"Authorization": f"Bearer {current_app.config['AUTH_TOKEN']}"}
-    resp = requests.post(f"{current_app.config['MESHING_ENDPOINT']}/api/v1/table/{table_id}/remeshing",
-                            data=json.dumps({"new_lvl2_ids": new_lvl2_ids},
-                                            cls=current_app.json_encoder),
-                            params={'priority': is_priority},
-                            headers=auth_header)
+    resp = requests.post(
+        f"{current_app.config['MESHING_ENDPOINT']}/api/v1/table/{table_id}/remeshing",
+        data=json.dumps({"new_lvl2_ids": new_lvl2_ids}, cls=current_app.json_encoder),
+        params={"priority": is_priority},
+        headers=auth_header,
+    )
     resp.raise_for_status()
+
 
 ### MERGE ----------------------------------------------------------------------
 
@@ -385,7 +394,7 @@ def handle_merge(table_id):
     current_app.table_id = table_id
 
     nodes = json.loads(request.data)
-    is_priority = request.args.get('priority', True, type=str2bool)
+    is_priority = request.args.get("priority", True, type=str2bool)
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
 
@@ -400,7 +409,7 @@ def handle_merge(table_id):
     for node in nodes:
         node_ids.append(node[0])
         coords.append(np.array(node[1:]) / cg.segmentation_resolution)
-    
+
     atomic_edge = handle_supervoxel_id_lookup(cg, coords, node_ids)
 
     # Protection from long range mergers
@@ -430,8 +439,9 @@ def handle_merge(table_id):
         raise cg_exceptions.BadRequest(str(e))
 
     if ret.new_root_ids is None:
-        raise cg_exceptions.InternalServerError("Could not merge selected "
-                                                "supervoxel.")
+        raise cg_exceptions.InternalServerError(
+            "Could not merge selected " "supervoxel."
+        )
 
     current_app.logger.debug(("lvl2_nodes:", ret.new_lvl2_ids))
 
@@ -448,8 +458,8 @@ def handle_split(table_id):
     current_app.table_id = table_id
 
     data = json.loads(request.data)
-    is_priority = request.args.get('priority', True, type=str2bool)
-    mincut = request.args.get('mincut', True, type=str2bool)
+    is_priority = request.args.get("priority", True, type=str2bool)
+    mincut = request.args.get("mincut", True, type=str2bool)
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
 
@@ -473,9 +483,9 @@ def handle_split(table_id):
     node_idents = np.array(node_idents)
     sv_ids = handle_supervoxel_id_lookup(cg, coords, node_ids)
 
-    current_app.logger.debug({"node_id": node_ids,
-                               "sv_id": sv_ids,
-                               "node_ident": node_idents})
+    current_app.logger.debug(
+        {"node_id": node_ids, "sv_id": sv_ids, "node_ident": node_idents}
+    )
 
     try:
         ret = cg.remove_edges(
@@ -520,7 +530,7 @@ def handle_undo(table_id):
     current_app.table_id = table_id
 
     data = json.loads(request.data)
-    is_priority = request.args.get('priority', True, type=str2bool)
+    is_priority = request.args.get("priority", True, type=str2bool)
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
 
@@ -560,7 +570,7 @@ def handle_redo(table_id):
     current_app.table_id = table_id
 
     data = json.loads(request.data)
-    is_priority = request.args.get('priority', True, type=str2bool)
+    is_priority = request.args.get("priority", True, type=str2bool)
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
 
@@ -665,8 +675,7 @@ def all_user_operations(table_id):
             timestamp = entry["timestamp"]
             timestamp_list.append(timestamp)
 
-    return {"operation_id": valid_entry_ids,
-         "timestamp": timestamp_list}
+    return {"operation_id": valid_entry_ids, "timestamp": timestamp_list}
 
 
 ### CHILDREN -------------------------------------------------------------------
@@ -713,7 +722,7 @@ def handle_leaves(table_id, root_id):
             int(root_id),
             bounding_box=bounding_box,
             bb_is_coordinate=True,
-            return_layers=[stop_layer]
+            return_layers=[stop_layer],
         )
         if isinstance(subgraph, np.ndarray):
             return subgraph
@@ -724,7 +733,7 @@ def handle_leaves(table_id, root_id):
                 for children_at_layer in node_subgraph.values():
                     result.append(children_at_layer)
             return np.concatenate(result)
-    else: 
+    else:
         atomic_ids = cg.get_subgraph_nodes(
             int(root_id), bounding_box=bounding_box, bb_is_coordinate=True
         )
@@ -846,9 +855,8 @@ def tabular_change_log_recent(table_id):
         user_list.append(user_id)
 
     return pd.DataFrame.from_dict(
-        {"operation_id": entry_ids,
-         "timestamp": timestamp_list,
-         "user_id": user_list})
+        {"operation_id": entry_ids, "timestamp": timestamp_list, "user_id": user_list}
+    )
 
 
 def tabular_change_log(table_id, root_id, get_root_ids, filtered):
@@ -865,12 +873,15 @@ def tabular_change_log(table_id, root_id, get_root_ids, filtered):
     cg = app_utils.get_cg(table_id)
     segment_history = cg_history.SegmentHistory(cg, int(root_id))
 
-    tab = segment_history.get_tabular_changelog(with_ids=get_root_ids,
-                                                filtered=filtered)
+    tab = segment_history.get_tabular_changelog(
+        with_ids=get_root_ids, filtered=filtered
+    )
 
     try:
-        tab["user_name"] = get_usernames(np.array(tab["user_id"], dtype=np.int).squeeze(),
-                                         current_app.config['AUTH_TOKEN'])
+        tab["user_name"] = get_usernames(
+            np.array(tab["user_id"], dtype=np.int).squeeze(),
+            current_app.config["AUTH_TOKEN"],
+        )
     except:
         current_app.logger.error(f"Could not retrieve user names for {root_id}")
 
@@ -901,11 +912,12 @@ def merge_log(table_id, root_id):
 
 def handle_lineage_graph(table_id, root_id=None):
     from networkx import node_link_data
+
     current_app.table_id = table_id
     user_id = str(g.auth_user["id"])
     current_app.user_id = user_id
 
-    def _parse_timestamp(arg_name, default_timestamp = 0):
+    def _parse_timestamp(arg_name, default_timestamp=0):
         """Convert seconds since epoch to UTC datetime."""
         try:
             return float(request.args.get(arg_name, default_timestamp))
@@ -923,11 +935,13 @@ def handle_lineage_graph(table_id, root_id=None):
     cg = app_utils.get_cg(table_id)
     if root_id is None:
         from ...backend.lineage import lineage_graph
+
         root_ids = np.array(json.loads(request.data)["root_ids"], dtype=np.uint64)
         graph = lineage_graph(cg, root_ids, timestamp_past, timestamp_future)
         return node_link_data(graph)
     graph = cg_history.SegmentHistory(cg, int(root_id)).get_change_log_graph(
-        timestamp_past, timestamp_future)
+        timestamp_past, timestamp_future
+    )
     return node_link_data(graph)
 
 
@@ -957,8 +971,7 @@ def handle_past_id_mapping(table_id):
 
         past_id_mapping[int(root_id)] = nodes[in_degrees == 0]
 
-    return {"past_id_map": past_id_mapping,
-            "future_id_map": future_id_mapping}
+    return {"past_id_map": past_id_mapping, "future_id_map": future_id_mapping}
 
 
 def last_edit(table_id, root_id):
@@ -1028,10 +1041,11 @@ def handle_contact_sites(table_id, root_id):
         compute_partner=partners,
         end_time=timestamp,
         as_list=as_list,
-        areas_only=areas_only
+        areas_only=areas_only,
     )
 
     return cs_list, cs_metadata
+
 
 def handle_pairwise_contact_sites(table_id, first_node_id, second_node_id):
     current_app.request_type = "pairwise_contact_sites"
@@ -1048,8 +1062,7 @@ def handle_pairwise_contact_sites(table_id, first_node_id, second_node_id):
                 "Timestamp parameter is not a valid" " unix timestamp"
             )
         )
-    exact_location = request.args.get("exact_location", True,
-                                      type=app_utils.toboolean)
+    exact_location = request.args.get("exact_location", True, type=app_utils.toboolean)
     cg = app_utils.get_cg(table_id)
     contact_sites_list, cs_metadata = contact_sites.get_contact_sites_pairwise(
         cg,
@@ -1089,18 +1102,18 @@ def handle_split_preview(table_id):
     node_idents = np.array(node_idents)
     sv_ids = handle_supervoxel_id_lookup(cg, coords, node_ids)
 
-    current_app.logger.debug({"node_id": node_ids,
-                               "sv_id": sv_ids,
-                               "node_ident": node_idents})
-                               
+    current_app.logger.debug(
+        {"node_id": node_ids, "sv_id": sv_ids, "node_ident": node_idents}
+    )
+
     try:
         supervoxel_ccs, illegal_split = cg._run_multicut(
             source_ids=sv_ids[node_idents == "sources"],
             sink_ids=sv_ids[node_idents == "sinks"],
             source_coords=coords[node_idents == "sources"],
             sink_coords=coords[node_idents == "sinks"],
-            bb_offset=(240,240,24),
-            split_preview=True
+            bb_offset=(240, 240, 24),
+            split_preview=True,
         )
 
     except cg_exceptions.PreconditionError as e:
@@ -1108,8 +1121,8 @@ def handle_split_preview(table_id):
 
     resp = {
         "supervoxel_connected_components": supervoxel_ccs,
-        "illegal_split": illegal_split
-        }
+        "illegal_split": illegal_split,
+    }
     return resp
 
 
@@ -1133,27 +1146,28 @@ def handle_find_path(table_id, precision_mode):
     for node in nodes:
         node_ids.append(node[0])
         coords.append(np.array(node[1:]) / cg.segmentation_resolution)
-    
-    source_supervoxel_id, target_supervoxel_id = handle_supervoxel_id_lookup(cg, coords, node_ids)
+
+    source_supervoxel_id, target_supervoxel_id = handle_supervoxel_id_lookup(
+        cg, coords, node_ids
+    )
 
     source_l2_id = cg.get_parent(source_supervoxel_id)
     target_l2_id = cg.get_parent(target_supervoxel_id)
 
     l2_path = analysis.find_l2_shortest_path(cg, source_l2_id, target_l2_id)
     if precision_mode:
-        centroids, failed_l2_ids = analysis.compute_mesh_centroids_of_l2_ids(cg, l2_path, flatten=True)
+        centroids, failed_l2_ids = analysis.compute_mesh_centroids_of_l2_ids(
+            cg, l2_path, flatten=True
+        )
         return {
             "centroids_list": centroids,
             "failed_l2_ids": failed_l2_ids,
-            "l2_path": l2_path
+            "l2_path": l2_path,
         }
     else:
         centroids = analysis.compute_rough_coordinate_path(cg, l2_path)
-        return {
-            "centroids_list": centroids,
-            "failed_l2_ids": [],
-            "l2_path": l2_path
-        }
+        return {"centroids_list": centroids, "failed_l2_ids": [], "l2_path": l2_path}
+
 
 ### GET_LAYER2_SUBGRAPH
 def handle_get_layer2_graph(table_id, node_id):
@@ -1164,11 +1178,11 @@ def handle_get_layer2_graph(table_id, node_id):
 
     cg = app_utils.get_cg(table_id)
     edge_graph = analysis.get_lvl2_edge_list(cg, int(node_id))
-    return {
-        'edge_graph': edge_graph
-    }
+    return {"edge_graph": edge_graph}
+
 
 ### IS LATEST ROOTS --------------------------------------------------------------
+
 
 def handle_is_latest_roots(table_id, is_binary):
     current_app.request_type = "is_latest_roots"
@@ -1177,8 +1191,7 @@ def handle_is_latest_roots(table_id, is_binary):
     if is_binary:
         node_ids = np.frombuffer(request.data, np.uint64)
     else:
-        node_ids = np.array(json.loads(request.data)["node_ids"],
-                            dtype=np.uint64)
+        node_ids = np.array(json.loads(request.data)["node_ids"], dtype=np.uint64)
     # Convert seconds since epoch to UTC datetime
     try:
         timestamp = float(request.args.get("timestamp", time.time()))
@@ -1192,9 +1205,9 @@ def handle_is_latest_roots(table_id, is_binary):
     # Call ChunkedGraph
     cg = app_utils.get_cg(table_id)
 
-    row_dict = cg.read_node_id_rows(node_ids=node_ids,
-                                    columns=column_keys.Hierarchy.NewParent,
-                                    end_time=timestamp)
+    row_dict = cg.read_node_id_rows(
+        node_ids=node_ids, columns=column_keys.Hierarchy.NewParent, end_time=timestamp
+    )
 
     if not np.all(cg.get_chunk_layers(node_ids) == cg.n_layers):
         raise cg_exceptions.BadRequest("Some ids are not root ids.")
@@ -1203,11 +1216,14 @@ def handle_is_latest_roots(table_id, is_binary):
 
     return is_latest
 
+
 ### OPERATION DETAILS ------------------------------------------------------------
+
 
 def operation_details(table_id):
     def parse_attr(attr, val) -> str:
         from numpy import ndarray
+
         try:
             if isinstance(val, ndarray):
                 return (attr.key, val.tolist())
@@ -1225,7 +1241,7 @@ def operation_details(table_id):
     log_rows = cg.read_log_rows(operation_ids)
 
     result = {}
-    for k,v in log_rows.items():
+    for k, v in log_rows.items():
         details = {}
         for _k, _v in v.items():
             _k, _v = parse_attr(_k, _v)

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -8,6 +8,8 @@ import os
 from io import BytesIO as IO
 from datetime import datetime
 import requests
+import networkx as nx
+from scipy import spatial
 
 import numpy as np
 from pytz import UTC

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -8,8 +8,6 @@ import os
 from io import BytesIO as IO
 from datetime import datetime
 import requests
-import networkx as nx
-from scipy import spatial
 
 import numpy as np
 from pytz import UTC
@@ -27,18 +25,6 @@ from pychunkedgraph.backend import history as cg_history
 from pychunkedgraph.backend.utils import column_keys
 from pychunkedgraph.graph_analysis import analysis, contact_sites
 from pychunkedgraph.backend.graphoperation import GraphEditOperation
-
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    NamedTuple,
-)
 
 __api_versions__ = [0, 1]
 __segmentation_url_prefix__ = os.environ.get("SEGMENTATION_URL_PREFIX", "segmentation")

--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -28,6 +28,18 @@ from pychunkedgraph.backend.utils import column_keys
 from pychunkedgraph.graph_analysis import analysis, contact_sites
 from pychunkedgraph.backend.graphoperation import GraphEditOperation
 
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    NamedTuple,
+)
+
 __api_versions__ = [0, 1]
 __segmentation_url_prefix__ = os.environ.get("SEGMENTATION_URL_PREFIX", "segmentation")
 

--- a/pychunkedgraph/backend/chunkedgraph.py
+++ b/pychunkedgraph/backend/chunkedgraph.py
@@ -1465,6 +1465,7 @@ class ChunkedGraph(object):
 
         bbox = np.array([np.min(coordinates, axis=0) - max_dist_vx, 
                          np.max(coordinates, axis=0) + max_dist_vx + 1])
+        bbox = bbox.astype(np.int)
         
         local_sv_seg = self.cv[bbox[0, 0]: bbox[1, 0], bbox[0, 1]: bbox[1, 1], bbox[0, 2]: bbox[1, 2]].squeeze()
         local_sv_ids = fastremap.unique(local_sv_seg).squeeze()

--- a/pychunkedgraph/backend/chunkedgraph.py
+++ b/pychunkedgraph/backend/chunkedgraph.py
@@ -15,13 +15,23 @@ import fastremap
 from itertools import chain
 from multiwrapper import multiprocessing_utils as mu
 from pychunkedgraph.backend import cutting, chunkedgraph_comp, flatgraph_utils
-from pychunkedgraph.backend.chunkedgraph_utils import compute_indices_pandas, \
-    compute_bitmasks, get_google_compatible_time_stamp, \
-    get_time_range_filter, get_time_range_and_column_filter, get_max_time, \
-    combine_cross_chunk_edge_dicts, get_min_time, partial_row_data_to_column_dict
+from pychunkedgraph.backend.chunkedgraph_utils import (
+    compute_indices_pandas,
+    compute_bitmasks,
+    get_google_compatible_time_stamp,
+    get_time_range_filter,
+    get_time_range_and_column_filter,
+    get_max_time,
+    combine_cross_chunk_edge_dicts,
+    get_min_time,
+    partial_row_data_to_column_dict,
+)
 from pychunkedgraph.backend.utils import serializers, column_keys, row_keys, basetypes
-from pychunkedgraph.backend import chunkedgraph_exceptions as cg_exceptions, \
-    chunkedgraph_edits as cg_edits, ChunkedGraphMeta
+from pychunkedgraph.backend import (
+    chunkedgraph_exceptions as cg_exceptions,
+    chunkedgraph_edits as cg_edits,
+    ChunkedGraphMeta,
+)
 from pychunkedgraph.backend.graphoperation import (
     GraphEditOperation,
     MergeOperation,
@@ -30,21 +40,41 @@ from pychunkedgraph.backend.graphoperation import (
     UndoOperation,
     RedoOperation,
 )
+
 # from pychunkedgraph.meshing import meshgen
 
 from google.api_core.retry import Retry, if_exception_type
-from google.api_core.exceptions import Aborted, DeadlineExceeded, \
-    ServiceUnavailable
+from google.api_core.exceptions import Aborted, DeadlineExceeded, ServiceUnavailable
 from google.auth import credentials
 from google.cloud import bigtable
-from google.cloud.bigtable.row_filters import TimestampRange, \
-    TimestampRangeFilter, ColumnRangeFilter, ValueRangeFilter, RowFilterChain, \
-    ColumnQualifierRegexFilter, RowFilterUnion, ConditionalRowFilter, \
-    PassAllFilter, RowFilter, RowKeyRegexFilter, FamilyNameRegexFilter
+from google.cloud.bigtable.row_filters import (
+    TimestampRange,
+    TimestampRangeFilter,
+    ColumnRangeFilter,
+    ValueRangeFilter,
+    RowFilterChain,
+    ColumnQualifierRegexFilter,
+    RowFilterUnion,
+    ConditionalRowFilter,
+    PassAllFilter,
+    RowFilter,
+    RowKeyRegexFilter,
+    FamilyNameRegexFilter,
+)
 from google.cloud.bigtable.row_set import RowSet
 from google.cloud.bigtable.column_family import MaxVersionsGCRule
 
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union, NamedTuple
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    NamedTuple,
+)
 
 
 HOME = os.path.expanduser("~")
@@ -53,8 +83,9 @@ LOCK_EXPIRED_TIME_DELTA = datetime.timedelta(minutes=3, seconds=0)
 UTC = pytz.UTC
 
 # Setting environment wide credential path
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = \
-           HOME + "/.cloudvolume/secrets/google-secret.json"
+os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = (
+    HOME + "/.cloudvolume/secrets/google-secret.json"
+)
 
 
 class ChunkedGraph(object):
@@ -75,7 +106,7 @@ class ChunkedGraph(object):
         is_new: bool = False,
         logger: Optional[logging.Logger] = None,
         meta: Optional[ChunkedGraphMeta] = None,
-                ) -> None:
+    ) -> None:
 
         if logger is None:
             self.logger = logging.getLogger(f"{project_id}/{instance_id}/{table_id}")
@@ -90,8 +121,9 @@ class ChunkedGraph(object):
         if client is not None:
             self._client = client
         else:
-            self._client = bigtable.Client(project=project_id, admin=True,
-                                           credentials=credentials)
+            self._client = bigtable.Client(
+                project=project_id, admin=True, credentials=credentials
+            )
 
         self._instance = self.client.instance(instance_id)
         self._table_id = table_id
@@ -102,35 +134,52 @@ class ChunkedGraph(object):
             self._check_and_create_table()
 
         self._dataset_info = self.check_and_write_table_parameters(
-            column_keys.GraphSettings.DatasetInfo, dataset_info,
-            required=True, is_new=is_new)
+            column_keys.GraphSettings.DatasetInfo,
+            dataset_info,
+            required=True,
+            is_new=is_new,
+        )
 
-        self._cv_path = self._dataset_info["data_dir"]         # required
+        self._cv_path = self._dataset_info["data_dir"]  # required
         self._mesh_dir = self._dataset_info.get("mesh", None)  # optional
 
         self._n_layers = self.check_and_write_table_parameters(
-            column_keys.GraphSettings.LayerCount, n_layers,
-            required=True, is_new=is_new)
+            column_keys.GraphSettings.LayerCount, n_layers, required=True, is_new=is_new
+        )
         self._fan_out = self.check_and_write_table_parameters(
-            column_keys.GraphSettings.FanOut, fan_out,
-            required=True, is_new=is_new)
+            column_keys.GraphSettings.FanOut, fan_out, required=True, is_new=is_new
+        )
         s_bits_atomic_layer = self.check_and_write_table_parameters(
             column_keys.GraphSettings.SpatialBits,
             np.uint64(s_bits_atomic_layer),
-            required=False, is_new=is_new)
-        self._use_skip_connections = self.check_and_write_table_parameters(
-            column_keys.GraphSettings.SkipConnections,
-            np.uint64(use_skip_connections), required=False, is_new=is_new) > 0
+            required=False,
+            is_new=is_new,
+        )
+        self._use_skip_connections = (
+            self.check_and_write_table_parameters(
+                column_keys.GraphSettings.SkipConnections,
+                np.uint64(use_skip_connections),
+                required=False,
+                is_new=is_new,
+            )
+            > 0
+        )
         self._n_bits_root_counter = self.check_and_write_table_parameters(
             column_keys.GraphSettings.RootCounterBits,
             np.uint64(n_bits_root_counter),
-            required=False, is_new=is_new)
+            required=False,
+            is_new=is_new,
+        )
         self._chunk_size = self.check_and_write_table_parameters(
-            column_keys.GraphSettings.ChunkSize, chunk_size,
-            required=True, is_new=is_new)
+            column_keys.GraphSettings.ChunkSize,
+            chunk_size,
+            required=True,
+            is_new=is_new,
+        )
 
-        self._bitmasks = compute_bitmasks(self.n_layers, self.fan_out,
-                                          s_bits_atomic_layer)
+        self._bitmasks = compute_bitmasks(
+            self.n_layers, self.fan_out, s_bits_atomic_layer
+        )
 
         self._cv = None
 
@@ -147,12 +196,14 @@ class ChunkedGraph(object):
             lrbb = self._dataset_info["leaves_request_bounding_box"]
         else:
             lrbb = [int(x) for x in self.chunk_size]
-        self._dataset_info["graph"] = {"chunk_size": [int(x) for x in self.chunk_size],
-                                       "n_bits_for_layer_id": self._n_bits_for_layer_id,
-                                       "cv_mip": self._cv_mip,
-                                       "n_layers": self.n_layers,
-                                       "spatial_bit_masks": self.bitmasks,
-                                       "bounding_box": lrbb}
+        self._dataset_info["graph"] = {
+            "chunk_size": [int(x) for x in self.chunk_size],
+            "n_bits_for_layer_id": self._n_bits_for_layer_id,
+            "cv_mip": self._cv_mip,
+            "n_layers": self.n_layers,
+            "spatial_bit_masks": self.bitmasks,
+            "bounding_box": lrbb,
+        }
 
         self.meta = meta
 
@@ -198,8 +249,12 @@ class ChunkedGraph(object):
 
     @property
     def family_ids(self):
-        return [self.family_id, self.incrementer_family_id, self.log_family_id,
-                self.cross_edge_family_id]
+        return [
+            self.family_id,
+            self.incrementer_family_id,
+            self.log_family_id,
+            self.cross_edge_family_id,
+        ]
 
     @property
     def fan_out(self) -> np.uint64:
@@ -244,7 +299,7 @@ class ChunkedGraph(object):
     def cv_mesh_path(self) -> str:
         # EAFP
         try:
-            return self.dataset_info['mesh_metadata']['override_mesh_path']
+            return self.dataset_info["mesh_metadata"]["override_mesh_path"]
         except KeyError:
             return "%s/%s" % (self._cv_path, self._mesh_dir)
 
@@ -259,8 +314,9 @@ class ChunkedGraph(object):
     @property
     def cv(self) -> cloudvolume.CloudVolume:
         if self._cv is None:
-            self._cv = cloudvolume.CloudVolume(self._cv_path, mip=self._cv_mip,
-                                               info=self.dataset_info)
+            self._cv = cloudvolume.CloudVolume(
+                self._cv_path, mip=self._cv_mip, info=self.dataset_info
+            )
 
         return self._cv
 
@@ -273,7 +329,7 @@ class ChunkedGraph(object):
         return self.get_chunk_id(layer=int(self.n_layers), x=0, y=0, z=0)
 
     def _check_and_create_table(self) -> None:
-        """ Checks if table exists and creates new one if necessary """
+        """Checks if table exists and creates new one if necessary"""
         table_ids = [t.table_id for t in self.instance.list_tables()]
 
         if not self.table_id in table_ids:
@@ -281,25 +337,29 @@ class ChunkedGraph(object):
             f = self.table.column_family(self.family_id)
             f.create()
 
-            f_inc = self.table.column_family(self.incrementer_family_id,
-                                             gc_rule=MaxVersionsGCRule(1))
+            f_inc = self.table.column_family(
+                self.incrementer_family_id, gc_rule=MaxVersionsGCRule(1)
+            )
             f_inc.create()
 
             f_log = self.table.column_family(self.log_family_id)
             f_log.create()
 
-            f_ce = self.table.column_family(self.cross_edge_family_id,
-                                            gc_rule=MaxVersionsGCRule(1))
+            f_ce = self.table.column_family(
+                self.cross_edge_family_id, gc_rule=MaxVersionsGCRule(1)
+            )
             f_ce.create()
 
             self.logger.info(f"Table {self.table_id} created")
 
-    def check_and_write_table_parameters(self, column: column_keys._Column,
-                                         value: Optional[Union[str, np.uint64]] = None,
-                                         required: bool = True,
-                                         is_new: bool = False
-                                         ) -> Union[str, np.uint64]:
-        """ Checks if a parameter already exists in the table. If it already
+    def check_and_write_table_parameters(
+        self,
+        column: column_keys._Column,
+        value: Optional[Union[str, np.uint64]] = None,
+        required: bool = True,
+        is_new: bool = False,
+    ) -> Union[str, np.uint64]:
+        """Checks if a parameter already exists in the table. If it already
         exists it returns the stored value, else it stores the given value.
         Storing the given values can be enforced with `is_new`. The function
         raises an exception if no value is passed and the parameter does not
@@ -312,8 +372,7 @@ class ChunkedGraph(object):
         :return: Union[str, np.uint64]
             value
         """
-        setting = self.read_byte_row(row_key=row_keys.GraphSettings,
-                                     columns=column)
+        setting = self.read_byte_row(row_key=row_keys.GraphSettings, columns=column)
 
         if (not setting or is_new) and value is not None:
             row = self.mutate_row(row_keys.GraphSettings, {column: value})
@@ -345,7 +404,9 @@ class ChunkedGraph(object):
         self.bulk_write([row])
         return True
 
-    def set_dataset_info_from_dict(self, dataset_dict: Dict[str, Any], overwrite: bool = False):
+    def set_dataset_info_from_dict(
+        self, dataset_dict: Dict[str, Any], overwrite: bool = False
+    ):
         """
         Add key value pairs from a dict to the dataset info. Return dict from parameter to bool
         that signifies whether each parameter in the dict was written to the info.
@@ -371,7 +432,7 @@ class ChunkedGraph(object):
         return return_dict
 
     def is_in_bounds(self, coordinate: Sequence[int]):
-        """ Checks whether a coordinate is within the segmentation bounds
+        """Checks whether a coordinate is within the segmentation bounds
 
         :param coordinate: [int, int, int]
         :return bool
@@ -386,13 +447,15 @@ class ChunkedGraph(object):
             return True
 
     def get_serialized_info(self):
-        """ Rerturns dictionary that can be used to load this ChunkedGraph
+        """Rerturns dictionary that can be used to load this ChunkedGraph
 
         :return: dict
         """
-        info = {"table_id": self.table_id,
-                "instance_id": self.instance_id,
-                "project_id": self.project_id}
+        info = {
+            "table_id": self.table_id,
+            "instance_id": self.instance_id,
+            "project_id": self.project_id,
+        }
 
         try:
             info["credentials"] = self.client.credentials
@@ -401,27 +464,28 @@ class ChunkedGraph(object):
 
         return info
 
-
-    def adjust_vol_coordinates_to_cv(self, x: np.int, y: np.int, z: np.int,
-                                     resolution: Sequence[np.int]):
+    def adjust_vol_coordinates_to_cv(
+        self, x: np.int, y: np.int, z: np.int, resolution: Sequence[np.int]
+    ):
         resolution = np.array(resolution)
         scaling = np.array(self.cv.resolution / resolution, dtype=np.int)
 
-        x = (x / scaling[0] - self.vx_vol_bounds[0, 0])
-        y = (y / scaling[1] - self.vx_vol_bounds[1, 0])
-        z = (z / scaling[2] - self.vx_vol_bounds[2, 0])
+        x = x / scaling[0] - self.vx_vol_bounds[0, 0]
+        y = y / scaling[1] - self.vx_vol_bounds[1, 0]
+        z = z / scaling[2] - self.vx_vol_bounds[2, 0]
 
         return np.array([x, y, z])
 
-    def get_chunk_coordinates_from_vol_coordinates(self,
-                                                   x: np.int,
-                                                   y: np.int,
-                                                   z: np.int,
-                                                   resolution: Sequence[np.int],
-                                                   ceil: bool = False,
-                                                   layer: int = 1
-                                                   ) -> np.ndarray:
-        """ Translates volume coordinates to chunk_coordinates
+    def get_chunk_coordinates_from_vol_coordinates(
+        self,
+        x: np.int,
+        y: np.int,
+        z: np.int,
+        resolution: Sequence[np.int],
+        ceil: bool = False,
+        layer: int = 1,
+    ) -> np.ndarray:
+        """Translates volume coordinates to chunk_coordinates
 
         :param x: np.int
         :param y: np.int
@@ -449,16 +513,15 @@ class ChunkedGraph(object):
         return coords.astype(np.int)
 
     def get_chunk_layer(self, node_or_chunk_id: np.uint64) -> int:
-        """ Extract Layer from Node ID or Chunk ID
+        """Extract Layer from Node ID or Chunk ID
 
         :param node_or_chunk_id: np.uint64
         :return: int
         """
         return int(int(node_or_chunk_id) >> 64 - self._n_bits_for_layer_id)
 
-    def get_chunk_layers(self, node_or_chunk_ids: Sequence[np.uint64]
-                         ) -> np.ndarray:
-        """ Extract Layers from Node IDs or Chunk IDs
+    def get_chunk_layers(self, node_or_chunk_ids: Sequence[np.uint64]) -> np.ndarray:
+        """Extract Layers from Node IDs or Chunk IDs
 
         :param node_or_chunk_ids: np.ndarray
         :return: np.ndarray
@@ -468,9 +531,8 @@ class ChunkedGraph(object):
 
         return self._get_chunk_layer_vec(node_or_chunk_ids)
 
-    def get_chunk_coordinates(self, node_or_chunk_id: np.uint64
-                              ) -> np.ndarray:
-        """ Extract X, Y and Z coordinate from Node ID or Chunk ID
+    def get_chunk_coordinates(self, node_or_chunk_id: np.uint64) -> np.ndarray:
+        """Extract X, Y and Z coordinate from Node ID or Chunk ID
 
         :param node_or_chunk_id: np.uint64
         :return: Tuple(int, int, int)
@@ -487,12 +549,15 @@ class ChunkedGraph(object):
         z = int(node_or_chunk_id) >> z_offset & 2 ** bits_per_dim - 1
         return np.array([x, y, z])
 
-    def get_chunk_id(self, node_id: Optional[np.uint64] = None,
-                     layer: Optional[int] = None,
-                     x: Optional[int] = None,
-                     y: Optional[int] = None,
-                     z: Optional[int] = None) -> np.uint64:
-        """ (1) Extract Chunk ID from Node ID
+    def get_chunk_id(
+        self,
+        node_id: Optional[np.uint64] = None,
+        layer: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        z: Optional[int] = None,
+    ) -> np.uint64:
+        """(1) Extract Chunk ID from Node ID
             (2) Build Chunk ID from Layer, X, Y and Z components
 
         :param node_id: np.uint64
@@ -502,8 +567,7 @@ class ChunkedGraph(object):
         :param z: int
         :return: np.uint64
         """
-        assert node_id is not None or \
-               all(v is not None for v in [layer, x, y, z])
+        assert node_id is not None or all(v is not None for v in [layer, x, y, z])
 
         if node_id is not None:
             layer = self.get_chunk_layer(node_id)
@@ -514,25 +578,28 @@ class ChunkedGraph(object):
             return np.uint64((int(node_id) >> chunk_offset) << chunk_offset)
         else:
 
-            if not(x < 2 ** bits_per_dim and
-                   y < 2 ** bits_per_dim and
-                   z < 2 ** bits_per_dim):
-                raise Exception("Chunk coordinate is out of range for"
-                                "this graph on layer %d with %d bits/dim."
-                                "[%d, %d, %d]; max = %d."
-                                % (layer, bits_per_dim, x, y, z,
-                                   2 ** bits_per_dim))
+            if not (
+                x < 2 ** bits_per_dim
+                and y < 2 ** bits_per_dim
+                and z < 2 ** bits_per_dim
+            ):
+                raise Exception(
+                    "Chunk coordinate is out of range for"
+                    "this graph on layer %d with %d bits/dim."
+                    "[%d, %d, %d]; max = %d."
+                    % (layer, bits_per_dim, x, y, z, 2 ** bits_per_dim)
+                )
 
             layer_offset = 64 - self._n_bits_for_layer_id
             x_offset = layer_offset - bits_per_dim
             y_offset = x_offset - bits_per_dim
             z_offset = y_offset - bits_per_dim
-            return np.uint64(layer << layer_offset | x << x_offset |
-                             y << y_offset | z << z_offset)
+            return np.uint64(
+                layer << layer_offset | x << x_offset | y << y_offset | z << z_offset
+            )
 
-    def get_chunk_ids_from_node_ids(self, node_ids: Iterable[np.uint64]
-                                    ) -> np.ndarray:
-        """ Extract a list of Chunk IDs from a list of Node IDs
+    def get_chunk_ids_from_node_ids(self, node_ids: Iterable[np.uint64]) -> np.ndarray:
+        """Extract a list of Chunk IDs from a list of Node IDs
 
         :param node_ids: np.ndarray(dtype=np.uint64)
         :return: np.ndarray(dtype=np.uint64)
@@ -543,7 +610,7 @@ class ChunkedGraph(object):
         return self._get_chunk_id_vec(node_ids)
 
     def get_child_chunk_ids(self, node_or_chunk_id: np.uint64) -> np.ndarray:
-        """ Calculates the ids of the children chunks in the next lower layer
+        """Calculates the ids of the children chunks in the next lower layer
 
         :param node_or_chunk_id: np.uint64
         :return: np.ndarray
@@ -555,49 +622,53 @@ class ChunkedGraph(object):
             return np.array([])
         elif chunk_layer == 2:
             x, y, z = chunk_coords
-            return np.array([self.get_chunk_id(layer=chunk_layer-1,
-                                               x=x, y=y, z=z)])
+            return np.array([self.get_chunk_id(layer=chunk_layer - 1, x=x, y=y, z=z)])
         else:
             chunk_ids = []
-            for dcoord in itertools.product(*[range(self.fan_out)]*3):
+            for dcoord in itertools.product(*[range(self.fan_out)] * 3):
                 x, y, z = chunk_coords * self.fan_out + np.array(dcoord)
-                child_chunk_id = self.get_chunk_id(layer=chunk_layer-1,
-                                                   x=x, y=y, z=z)
+                child_chunk_id = self.get_chunk_id(layer=chunk_layer - 1, x=x, y=y, z=z)
                 chunk_ids.append(child_chunk_id)
 
             return np.array(chunk_ids)
 
     def get_parent_chunk_ids(self, node_or_chunk_id: np.uint64) -> np.ndarray:
-        """ Creates list of chunk parent ids
+        """Creates list of chunk parent ids
 
         :param node_or_chunk_id: np.uint64
         :return: np.ndarray
         """
-        parent_chunk_layers = range(self.get_chunk_layer(node_or_chunk_id) + 1,
-                                    self.n_layers + 1)
+        parent_chunk_layers = range(
+            self.get_chunk_layer(node_or_chunk_id) + 1, self.n_layers + 1
+        )
         chunk_coord = self.get_chunk_coordinates(node_or_chunk_id)
 
         parent_chunk_ids = [self.get_chunk_id(node_or_chunk_id)]
         for layer in parent_chunk_layers:
             chunk_coord = chunk_coord // self.fan_out
-            parent_chunk_ids.append(self.get_chunk_id(layer=layer,
-                                                      x=chunk_coord[0],
-                                                      y=chunk_coord[1],
-                                                      z=chunk_coord[2]))
+            parent_chunk_ids.append(
+                self.get_chunk_id(
+                    layer=layer, x=chunk_coord[0], y=chunk_coord[1], z=chunk_coord[2]
+                )
+            )
         return np.array(parent_chunk_ids, dtype=np.uint64)
 
     def get_parent_chunk_id_dict(self, node_or_chunk_id: np.uint64) -> dict:
-        """ Creates dict of chunk parent ids
+        """Creates dict of chunk parent ids
 
         :param node_or_chunk_id: np.uint64
         :return: dict
         """
         chunk_layer = self.get_chunk_layer(node_or_chunk_id)
-        return dict(zip(range(chunk_layer, self.n_layers + 1),
-                        self.get_parent_chunk_ids(node_or_chunk_id)))
+        return dict(
+            zip(
+                range(chunk_layer, self.n_layers + 1),
+                self.get_parent_chunk_ids(node_or_chunk_id),
+            )
+        )
 
     def get_segment_id_limit(self, node_or_chunk_id: np.uint64) -> np.uint64:
-        """ Get maximum possible Segment ID for given Node ID or Chunk ID
+        """Get maximum possible Segment ID for given Node ID or Chunk ID
 
         :param node_or_chunk_id: np.uint64
         :return: np.uint64
@@ -609,7 +680,7 @@ class ChunkedGraph(object):
         return np.uint64(2 ** chunk_offset - 1)
 
     def get_segment_id(self, node_id: np.uint64) -> np.uint64:
-        """ Extract Segment ID from Node ID
+        """Extract Segment ID from Node ID
 
         :param node_id: np.uint64
         :return: np.uint64
@@ -617,13 +688,16 @@ class ChunkedGraph(object):
 
         return node_id & self.get_segment_id_limit(node_id)
 
-    def get_node_id(self, segment_id: np.uint64,
-                    chunk_id: Optional[np.uint64] = None,
-                    layer: Optional[int] = None,
-                    x: Optional[int] = None,
-                    y: Optional[int] = None,
-                    z: Optional[int] = None) -> np.uint64:
-        """ (1) Build Node ID from Segment ID and Chunk ID
+    def get_node_id(
+        self,
+        segment_id: np.uint64,
+        chunk_id: Optional[np.uint64] = None,
+        layer: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        z: Optional[int] = None,
+    ) -> np.uint64:
+        """(1) Build Node ID from Segment ID and Chunk ID
             (2) Build Node ID from Segment ID, Layer, X, Y and Z components
 
         :param segment_id: np.uint64
@@ -649,14 +723,17 @@ class ChunkedGraph(object):
 
         # This increments the row entry and returns the value AFTER incrementing
         latest_row = append_row.commit()
-        max_segment_id = column.deserialize(latest_row[column.family_id][column.key][0][0])
+        max_segment_id = column.deserialize(
+            latest_row[column.family_id][column.key][0][0]
+        )
 
-        min_segment_id = max_segment_id  + np.uint64(1) - step
+        min_segment_id = max_segment_id + np.uint64(1) - step
         return min_segment_id, max_segment_id
 
-    def get_unique_segment_id_root_row(self, step: int = 1,
-                                       counter_id: int = None) -> np.ndarray:
-        """ Return unique Segment ID for the Root Chunk
+    def get_unique_segment_id_root_row(
+        self, step: int = 1, counter_id: int = None
+    ) -> np.ndarray:
+        """Return unique Segment ID for the Root Chunk
 
         atomic counter
 
@@ -665,8 +742,7 @@ class ChunkedGraph(object):
         :return: np.uint64
         """
         if self.n_bits_root_counter == 0:
-            return self.get_unique_segment_id_range(self.root_chunk_id,
-                                                    step=step)
+            return self.get_unique_segment_id_range(self.root_chunk_id, step=step)
 
         n_counters = np.uint64(2 ** self._n_bits_root_counter)
 
@@ -676,21 +752,26 @@ class ChunkedGraph(object):
             counter_id = np.uint64(counter_id % n_counters)
 
         row_key = serializers.serialize_key(
-            f"i{serializers.pad_node_id(self.root_chunk_id)}_{counter_id}")
+            f"i{serializers.pad_node_id(self.root_chunk_id)}_{counter_id}"
+        )
 
-        min_segment_id, max_segment_id = self._get_unique_range(row_key=row_key,
-                                                                step=step)
+        min_segment_id, max_segment_id = self._get_unique_range(
+            row_key=row_key, step=step
+        )
 
-        segment_id_range = np.arange(min_segment_id * n_counters + counter_id,
-                                     max_segment_id * n_counters +
-                                     np.uint64(1) + counter_id, n_counters,
-                                     dtype=basetypes.SEGMENT_ID)
+        segment_id_range = np.arange(
+            min_segment_id * n_counters + counter_id,
+            max_segment_id * n_counters + np.uint64(1) + counter_id,
+            n_counters,
+            dtype=basetypes.SEGMENT_ID,
+        )
 
         return segment_id_range
 
-    def get_unique_segment_id_range(self, chunk_id: np.uint64, step: int = 1
-                                    ) -> np.ndarray:
-        """ Return unique Segment ID for given Chunk ID
+    def get_unique_segment_id_range(
+        self, chunk_id: np.uint64, step: int = 1
+    ) -> np.ndarray:
+        """Return unique Segment ID for given Chunk ID
 
         atomic counter
 
@@ -698,21 +779,23 @@ class ChunkedGraph(object):
         :param step: int
         :return: np.uint64
         """
-        if self.n_layers == self.get_chunk_layer(chunk_id) and \
-                self.n_bits_root_counter > 0:
+        if (
+            self.n_layers == self.get_chunk_layer(chunk_id)
+            and self.n_bits_root_counter > 0
+        ):
             return self.get_unique_segment_id_root_row(step=step)
 
-        row_key = serializers.serialize_key(
-            "i%s" % serializers.pad_node_id(chunk_id))
-        min_segment_id, max_segment_id = self._get_unique_range(row_key=row_key,
-                                                                step=step)
-        segment_id_range = np.arange(min_segment_id,
-                                     max_segment_id + np.uint64(1),
-                                     dtype=basetypes.SEGMENT_ID)
+        row_key = serializers.serialize_key("i%s" % serializers.pad_node_id(chunk_id))
+        min_segment_id, max_segment_id = self._get_unique_range(
+            row_key=row_key, step=step
+        )
+        segment_id_range = np.arange(
+            min_segment_id, max_segment_id + np.uint64(1), dtype=basetypes.SEGMENT_ID
+        )
         return segment_id_range
 
     def get_unique_segment_id(self, chunk_id: np.uint64) -> np.uint64:
-        """ Return unique Segment ID for given Chunk ID
+        """Return unique Segment ID for given Chunk ID
 
         atomic counter
 
@@ -723,9 +806,10 @@ class ChunkedGraph(object):
 
         return self.get_unique_segment_id_range(chunk_id=chunk_id, step=1)[0]
 
-    def get_unique_node_id_range(self, chunk_id: np.uint64, step: int = 1
-                                 ) -> np.ndarray:
-        """ Return unique Node ID range for given Chunk ID
+    def get_unique_node_id_range(
+        self, chunk_id: np.uint64, step: int = 1
+    ) -> np.ndarray:
+        """Return unique Node ID range for given Chunk ID
 
         atomic counter
 
@@ -734,15 +818,16 @@ class ChunkedGraph(object):
         :return: np.uint64
         """
 
-        segment_ids = self.get_unique_segment_id_range(chunk_id=chunk_id,
-                                                       step=step)
+        segment_ids = self.get_unique_segment_id_range(chunk_id=chunk_id, step=step)
 
-        node_ids = np.array([self.get_node_id(segment_id, chunk_id)
-                             for segment_id in segment_ids], dtype=np.uint64)
+        node_ids = np.array(
+            [self.get_node_id(segment_id, chunk_id) for segment_id in segment_ids],
+            dtype=np.uint64,
+        )
         return node_ids
 
     def get_unique_node_id(self, chunk_id: np.uint64) -> np.uint64:
-        """ Return unique Node ID for given Chunk ID
+        """Return unique Node ID for given Chunk ID
 
         atomic counter
 
@@ -753,7 +838,7 @@ class ChunkedGraph(object):
         return self.get_unique_node_id_range(chunk_id=chunk_id, step=1)[0]
 
     def get_max_seg_id_root_chunk(self) -> np.uint64:
-        """  Gets maximal root id based on the atomic counter
+        """Gets maximal root id based on the atomic counter
 
         This is an approximation. It is not guaranteed that all ids smaller or
         equal to this id exists. However, it is guaranteed that no larger id
@@ -768,20 +853,19 @@ class ChunkedGraph(object):
         max_value = 0
         for counter_id in range(n_counters):
             row_key = serializers.serialize_key(
-                f"i{serializers.pad_node_id(self.root_chunk_id)}_{counter_id}")
+                f"i{serializers.pad_node_id(self.root_chunk_id)}_{counter_id}"
+            )
 
-            row = self.read_byte_row(row_key,
-                                     columns=column_keys.Concurrency.CounterID)
+            row = self.read_byte_row(row_key, columns=column_keys.Concurrency.CounterID)
 
-            counter = basetypes.SEGMENT_ID.type(row[0].value if row else 0) * \
-                      n_counters
+            counter = basetypes.SEGMENT_ID.type(row[0].value if row else 0) * n_counters
             if counter > max_value:
                 max_value = counter
 
         return max_value
 
     def get_max_seg_id(self, chunk_id: np.uint64) -> np.uint64:
-        """  Gets maximal seg id in a chunk based on the atomic counter
+        """Gets maximal seg id in a chunk based on the atomic counter
 
         This is an approximation. It is not guaranteed that all ids smaller or
         equal to this id exists. However, it is guaranteed that no larger id
@@ -790,21 +874,21 @@ class ChunkedGraph(object):
 
         :return: uint64
         """
-        if self.n_layers == self.get_chunk_layer(chunk_id) and \
-                self.n_bits_root_counter > 0:
+        if (
+            self.n_layers == self.get_chunk_layer(chunk_id)
+            and self.n_bits_root_counter > 0
+        ):
             return self.get_max_seg_id_root_chunk()
 
         # Incrementer row keys start with an "i"
-        row_key = serializers.serialize_key(
-            "i%s" % serializers.pad_node_id(chunk_id))
-        row = self.read_byte_row(row_key,
-                                 columns=column_keys.Concurrency.CounterID)
+        row_key = serializers.serialize_key("i%s" % serializers.pad_node_id(chunk_id))
+        row = self.read_byte_row(row_key, columns=column_keys.Concurrency.CounterID)
 
         # Read incrementer value (default to 0) and interpret is as Segment ID
         return basetypes.SEGMENT_ID.type(row[0].value if row else 0)
 
     def get_max_node_id(self, chunk_id: np.uint64) -> np.uint64:
-        """  Gets maximal node id in a chunk based on the atomic counter
+        """Gets maximal node id in a chunk based on the atomic counter
 
         This is an approximation. It is not guaranteed that all ids smaller or
         equal to this id exists. However, it is guaranteed that no larger id
@@ -818,7 +902,7 @@ class ChunkedGraph(object):
         return self.get_node_id(segment_id=max_seg_id, chunk_id=chunk_id)
 
     def get_unique_operation_id(self) -> np.uint64:
-        """ Finds a unique operation id
+        """Finds a unique operation id
 
         atomic counter
 
@@ -842,7 +926,7 @@ class ChunkedGraph(object):
         return np.uint64(operation_id)
 
     def get_max_operation_id(self) -> np.int64:
-        """  Gets maximal operation id based on the atomic counter
+        """Gets maximal operation id based on the atomic counter
 
         This is an approximation. It is not guaranteed that all ids smaller or
         equal to this id exists. However, it is guaranteed that no larger id
@@ -857,7 +941,7 @@ class ChunkedGraph(object):
         return row[0].value if row else column.basetype(0)
 
     def get_cross_chunk_edges_layer(self, cross_edges):
-        """ Computes the layer in which a cross chunk edge becomes relevant.
+        """Computes the layer in which a cross chunk edge becomes relevant.
 
         I.e. if a cross chunk edge links two nodes in layer 4 this function
         returns 3.
@@ -874,21 +958,26 @@ class ChunkedGraph(object):
         cross_edge_coordinates = []
         for cross_edge in cross_edges:
             cross_edge_coordinates.append(
-                [self.get_chunk_coordinates(cross_edge[0]),
-                 self.get_chunk_coordinates(cross_edge[1])])
+                [
+                    self.get_chunk_coordinates(cross_edge[0]),
+                    self.get_chunk_coordinates(cross_edge[1]),
+                ]
+            )
 
         cross_edge_coordinates = np.array(cross_edge_coordinates, dtype=np.int)
 
         for layer in range(2, self.n_layers):
-            edge_diff = np.sum(np.abs(cross_edge_coordinates[:, 0] -
-                                      cross_edge_coordinates[:, 1]), axis=1)
+            edge_diff = np.sum(
+                np.abs(cross_edge_coordinates[:, 0] - cross_edge_coordinates[:, 1]),
+                axis=1,
+            )
             cross_chunk_edge_layers[edge_diff > 0] += 1
             cross_edge_coordinates = cross_edge_coordinates // self.fan_out
 
         return cross_chunk_edge_layers
 
     def get_cross_chunk_edge_dict(self, cross_edges):
-        """ Generates a cross chunk edge dict for a list of cross chunk edges
+        """Generates a cross chunk edge dict for a list of cross chunk edges
 
         :param cross_edges: n x 2 array
         :return: dict
@@ -898,31 +987,40 @@ class ChunkedGraph(object):
         cross_edge_dict = {}
 
         for l in range(2, self.n_layers):
-            cross_edge_dict[l] = column_keys.Connectivity.CrossChunkEdge.deserialize(b'')
+            cross_edge_dict[l] = column_keys.Connectivity.CrossChunkEdge.deserialize(
+                b""
+            )
 
         val_dict = {}
         for cc_layer in u_cce_layers:
             layer_cross_edges = cross_edges[cce_layers == cc_layer]
 
             if len(layer_cross_edges) > 0:
-                val_dict[column_keys.Connectivity.CrossChunkEdge[cc_layer]] = \
-                    layer_cross_edges
+                val_dict[
+                    column_keys.Connectivity.CrossChunkEdge[cc_layer]
+                ] = layer_cross_edges
                 cross_edge_dict[cc_layer] = layer_cross_edges
         return cross_edge_dict
 
     def read_byte_rows(
-            self,
-            start_key: Optional[bytes] = None,
-            end_key: Optional[bytes] = None,
-            end_key_inclusive: bool = False,
-            row_keys: Optional[Iterable[bytes]] = None,
-            columns: Optional[Union[Iterable[column_keys._Column], column_keys._Column]] = None,
-            start_time: Optional[datetime.datetime] = None,
-            end_time: Optional[datetime.datetime] = None,
-            end_time_inclusive: bool = False) -> Dict[bytes, Union[
-                Dict[column_keys._Column, List[bigtable.row_data.Cell]],
-                List[bigtable.row_data.Cell]
-            ]]:
+        self,
+        start_key: Optional[bytes] = None,
+        end_key: Optional[bytes] = None,
+        end_key_inclusive: bool = False,
+        row_keys: Optional[Iterable[bytes]] = None,
+        columns: Optional[
+            Union[Iterable[column_keys._Column], column_keys._Column]
+        ] = None,
+        start_time: Optional[datetime.datetime] = None,
+        end_time: Optional[datetime.datetime] = None,
+        end_time_inclusive: bool = False,
+    ) -> Dict[
+        bytes,
+        Union[
+            Dict[column_keys._Column, List[bigtable.row_data.Cell]],
+            List[bigtable.row_data.Cell],
+        ],
+    ]:
         """Main function for reading a row range or non-contiguous row sets from Bigtable using
         `bytes` keys.
 
@@ -963,7 +1061,8 @@ class ChunkedGraph(object):
             columns=columns,
             start_time=start_time,
             end_time=end_time,
-            end_inclusive=end_time_inclusive)
+            end_inclusive=end_time_inclusive,
+        )
 
         # Create filters: Rows
         row_set = RowSet()
@@ -976,10 +1075,13 @@ class ChunkedGraph(object):
                 start_key=start_key,
                 start_inclusive=True,
                 end_key=end_key,
-                end_inclusive=end_key_inclusive)
+                end_inclusive=end_key_inclusive,
+            )
         else:
-            raise cg_exceptions.PreconditionError("Need to either provide a valid set of rows, or"
-                                                  " both, a start row and an end row.")
+            raise cg_exceptions.PreconditionError(
+                "Need to either provide a valid set of rows, or"
+                " both, a start row and an end row."
+            )
 
         # Bigtable read with retries
         rows = self._execute_read(row_set=row_set, row_filter=filter_)
@@ -995,14 +1097,18 @@ class ChunkedGraph(object):
         return rows
 
     def read_byte_row(
-            self,
-            row_key: bytes,
-            columns: Optional[Union[Iterable[column_keys._Column], column_keys._Column]] = None,
-            start_time: Optional[datetime.datetime] = None,
-            end_time: Optional[datetime.datetime] = None,
-            end_time_inclusive: bool = False) -> \
-                Union[Dict[column_keys._Column, List[bigtable.row_data.Cell]],
-                      List[bigtable.row_data.Cell]]:
+        self,
+        row_key: bytes,
+        columns: Optional[
+            Union[Iterable[column_keys._Column], column_keys._Column]
+        ] = None,
+        start_time: Optional[datetime.datetime] = None,
+        end_time: Optional[datetime.datetime] = None,
+        end_time_inclusive: bool = False,
+    ) -> Union[
+        Dict[column_keys._Column, List[bigtable.row_data.Cell]],
+        List[bigtable.row_data.Cell],
+    ]:
         """Convenience function for reading a single row from Bigtable using its `bytes` keys.
 
         Arguments:
@@ -1029,8 +1135,13 @@ class ChunkedGraph(object):
                 If only a single `column_keys._Column` was requested, the List of cells is returned
                 directly.
         """
-        row = self.read_byte_rows(row_keys=[row_key], columns=columns, start_time=start_time,
-                                  end_time=end_time, end_time_inclusive=end_time_inclusive)
+        row = self.read_byte_rows(
+            row_keys=[row_key],
+            columns=columns,
+            start_time=start_time,
+            end_time=end_time,
+            end_time_inclusive=end_time_inclusive,
+        )
 
         if isinstance(columns, column_keys._Column):
             return row.get(row_key, [])
@@ -1038,18 +1149,24 @@ class ChunkedGraph(object):
             return row.get(row_key, {})
 
     def read_node_id_rows(
-            self,
-            start_id: Optional[np.uint64] = None,
-            end_id: Optional[np.uint64] = None,
-            end_id_inclusive: bool = False,
-            node_ids: Optional[Iterable[np.uint64]] = None,
-            columns: Optional[Union[Iterable[column_keys._Column], column_keys._Column]] = None,
-            start_time: Optional[datetime.datetime] = None,
-            end_time: Optional[datetime.datetime] = None,
-            end_time_inclusive: bool = False) -> Dict[np.uint64, Union[
-                Dict[column_keys._Column, List[bigtable.row_data.Cell]],
-                List[bigtable.row_data.Cell]
-            ]]:
+        self,
+        start_id: Optional[np.uint64] = None,
+        end_id: Optional[np.uint64] = None,
+        end_id_inclusive: bool = False,
+        node_ids: Optional[Iterable[np.uint64]] = None,
+        columns: Optional[
+            Union[Iterable[column_keys._Column], column_keys._Column]
+        ] = None,
+        start_time: Optional[datetime.datetime] = None,
+        end_time: Optional[datetime.datetime] = None,
+        end_time_inclusive: bool = False,
+    ) -> Dict[
+        np.uint64,
+        Union[
+            Dict[column_keys._Column, List[bigtable.row_data.Cell]],
+            List[bigtable.row_data.Cell],
+        ],
+    ]:
         """Convenience function for reading a row range or non-contiguous row sets from Bigtable
         representing NodeIDs.
 
@@ -1092,24 +1209,31 @@ class ChunkedGraph(object):
             start_key=to_bytes(start_id) if start_id is not None else None,
             end_key=to_bytes(end_id) if end_id is not None else None,
             end_key_inclusive=end_id_inclusive,
-            row_keys=(to_bytes(node_id) for node_id in node_ids) if node_ids is not None else None,
+            row_keys=(to_bytes(node_id) for node_id in node_ids)
+            if node_ids is not None
+            else None,
             columns=columns,
             start_time=start_time,
             end_time=end_time,
-            end_time_inclusive=end_time_inclusive)
+            end_time_inclusive=end_time_inclusive,
+        )
 
         # Convert row_keys back to Node IDs
         return {from_bytes(row_key): data for (row_key, data) in rows.items()}
 
     def read_node_id_row(
-            self,
-            node_id: np.uint64,
-            columns: Optional[Union[Iterable[column_keys._Column], column_keys._Column]] = None,
-            start_time: Optional[datetime.datetime] = None,
-            end_time: Optional[datetime.datetime] = None,
-            end_time_inclusive: bool = False) -> \
-                Union[Dict[column_keys._Column, List[bigtable.row_data.Cell]],
-                      List[bigtable.row_data.Cell]]:
+        self,
+        node_id: np.uint64,
+        columns: Optional[
+            Union[Iterable[column_keys._Column], column_keys._Column]
+        ] = None,
+        start_time: Optional[datetime.datetime] = None,
+        end_time: Optional[datetime.datetime] = None,
+        end_time_inclusive: bool = False,
+    ) -> Union[
+        Dict[column_keys._Column, List[bigtable.row_data.Cell]],
+        List[bigtable.row_data.Cell],
+    ]:
         """Convenience function for reading a single row from Bigtable, representing a NodeID.
 
         Arguments:
@@ -1136,13 +1260,22 @@ class ChunkedGraph(object):
                 If only a single `column_keys._Column` was requested, the List of cells is returned
                 directly.
         """
-        return self.read_byte_row(row_key=serializers.serialize_uint64(node_id), columns=columns,
-                                  start_time=start_time, end_time=end_time,
-                                  end_time_inclusive=end_time_inclusive)
+        return self.read_byte_row(
+            row_key=serializers.serialize_uint64(node_id),
+            columns=columns,
+            start_time=start_time,
+            end_time=end_time,
+            end_time_inclusive=end_time_inclusive,
+        )
 
-    def read_cross_chunk_edges(self, node_id: np.uint64, start_layer: int = 2,
-                               end_layer: int = None, flatten: bool = False) -> Dict:
-        """ Reads the cross chunk edge entry from the table for a given node id
+    def read_cross_chunk_edges(
+        self,
+        node_id: np.uint64,
+        start_layer: int = 2,
+        end_layer: int = None,
+        flatten: bool = False,
+    ) -> Dict:
+        """Reads the cross chunk edge entry from the table for a given node id
         and formats it as cross edge dict. If flatten is True, return an array of edges instead.
 
         :param node_id:
@@ -1161,16 +1294,20 @@ class ChunkedGraph(object):
 
         assert end_layer > start_layer and end_layer <= self.n_layers
 
-        columns = [column_keys.Connectivity.CrossChunkEdge[l]
-                   for l in range(start_layer, end_layer)]
+        columns = [
+            column_keys.Connectivity.CrossChunkEdge[l]
+            for l in range(start_layer, end_layer)
+        ]
         row_dict = self.read_node_id_row(node_id, columns=columns)
 
         if flatten:
-            cross_edge_array = np.zeros((0,2),dtype=np.uint64)
+            cross_edge_array = np.zeros((0, 2), dtype=np.uint64)
             for l in range(start_layer, end_layer):
                 col = column_keys.Connectivity.CrossChunkEdge[l]
                 if col in row_dict:
-                    cross_edge_array = np.concatenate((cross_edge_array, row_dict[col][0].value))
+                    cross_edge_array = np.concatenate(
+                        (cross_edge_array, row_dict[col][0].value)
+                    )
             return cross_edge_array
         else:
             cross_edge_dict = {}
@@ -1179,13 +1316,14 @@ class ChunkedGraph(object):
                 if col in row_dict:
                     cross_edge_dict[l] = row_dict[col][0].value
                 else:
-                    cross_edge_dict[l] = col.deserialize(b'')
+                    cross_edge_dict[l] = col.deserialize(b"")
 
             return cross_edge_dict
 
-    def read_cross_chunk_edges_for_nodes(self, node_ids: Sequence[np.uint64], start_layer: int = 2,
-                               end_layer: int = None) -> Dict:
-        """ Reads the cross chunk edge entry from the table for a given node id
+    def read_cross_chunk_edges_for_nodes(
+        self, node_ids: Sequence[np.uint64], start_layer: int = 2, end_layer: int = None
+    ) -> Dict:
+        """Reads the cross chunk edge entry from the table for a given node id
         and formats it as cross edge dict
 
         :param node_id:
@@ -1201,27 +1339,33 @@ class ChunkedGraph(object):
 
         assert end_layer > start_layer and end_layer <= self.n_layers
 
-        columns = [column_keys.Connectivity.CrossChunkEdge[l]
-                   for l in range(start_layer, end_layer)]
+        columns = [
+            column_keys.Connectivity.CrossChunkEdge[l]
+            for l in range(start_layer, end_layer)
+        ]
         row_dict = self.read_node_id_rows(node_ids=node_ids, columns=columns)
 
         cross_edge_dict = {}
         for node_id in row_dict:
-            cross_edge_array = np.zeros((0,2),dtype=np.uint64)
+            cross_edge_array = np.zeros((0, 2), dtype=np.uint64)
             for l in range(start_layer, end_layer):
                 col = column_keys.Connectivity.CrossChunkEdge[l]
                 if col in row_dict[node_id]:
-                    cross_edge_array = np.concatenate((cross_edge_array, row_dict[node_id][col][0].value))
+                    cross_edge_array = np.concatenate(
+                        (cross_edge_array, row_dict[node_id][col][0].value)
+                    )
             cross_edge_dict[node_id] = cross_edge_array
 
         return cross_edge_dict
 
-    def mutate_row(self, row_key: bytes,
-                   val_dict: Dict[column_keys._Column, Any],
-                   time_stamp: Optional[datetime.datetime] = None,
-                   isbytes: bool = False
-                   ) -> bigtable.row.Row:
-        """ Mutates a single row
+    def mutate_row(
+        self,
+        row_key: bytes,
+        val_dict: Dict[column_keys._Column, Any],
+        time_stamp: Optional[datetime.datetime] = None,
+        isbytes: bool = False,
+    ) -> bigtable.row.Row:
+        """Mutates a single row
 
         :param row_key: serialized bigtable row key
         :param val_dict: Dict[column_keys._TypedColumn: bytes]
@@ -1234,19 +1378,23 @@ class ChunkedGraph(object):
             if not isbytes:
                 value = column.serialize(value)
 
-            row.set_cell(column_family_id=column.family_id,
-                         column=column.key,
-                         value=value,
-                         timestamp=time_stamp)
+            row.set_cell(
+                column_family_id=column.family_id,
+                column=column.key,
+                value=value,
+                timestamp=time_stamp,
+            )
         return row
 
-    def bulk_write(self, rows: Iterable[bigtable.row.DirectRow],
-                   root_ids: Optional[Union[np.uint64,
-                                            Iterable[np.uint64]]] = None,
-                   operation_id: Optional[np.uint64] = None,
-                   slow_retry: bool = True,
-                   block_size: int = 2000):
-        """ Writes a list of mutated rows in bulk
+    def bulk_write(
+        self,
+        rows: Iterable[bigtable.row.DirectRow],
+        root_ids: Optional[Union[np.uint64, Iterable[np.uint64]]] = None,
+        operation_id: Optional[np.uint64] = None,
+        slow_retry: bool = True,
+        block_size: int = 2000,
+    ):
+        """Writes a list of mutated rows in bulk
 
         WARNING: If <rows> contains the same row (same row_key) and column
         key two times only the last one is effectively written to the BigTable
@@ -1269,27 +1417,33 @@ class ChunkedGraph(object):
             initial = 1
 
         retry_policy = Retry(
-            predicate=if_exception_type((Aborted,
-                                         DeadlineExceeded,
-                                         ServiceUnavailable)),
+            predicate=if_exception_type(
+                (Aborted, DeadlineExceeded, ServiceUnavailable)
+            ),
             initial=initial,
             maximum=15.0,
             multiplier=2.0,
-            deadline=LOCK_EXPIRED_TIME_DELTA.seconds)
+            deadline=LOCK_EXPIRED_TIME_DELTA.seconds,
+        )
 
         if root_ids is not None and operation_id is not None:
             if isinstance(root_ids, int):
                 root_ids = [root_ids]
 
             if not self.check_and_renew_root_locks(root_ids, operation_id):
-                raise cg_exceptions.LockError(f"Root lock renewal failed for operation ID {operation_id}")
+                raise cg_exceptions.LockError(
+                    f"Root lock renewal failed for operation ID {operation_id}"
+                )
 
         for i_row in range(0, len(rows), block_size):
-            status = self.table.mutate_rows(rows[i_row: i_row + block_size],
-                                            retry=retry_policy)
+            status = self.table.mutate_rows(
+                rows[i_row : i_row + block_size], retry=retry_policy
+            )
 
             if not all(status):
-                raise cg_exceptions.ChunkedGraphError(f"Bulk write failed for operation ID {operation_id}")
+                raise cg_exceptions.ChunkedGraphError(
+                    f"Bulk write failed for operation ID {operation_id}"
+                )
 
     def _execute_read_thread(self, row_set_and_filter: Tuple[RowSet, RowFilter]):
         row_set, row_filter = row_set_and_filter
@@ -1299,13 +1453,13 @@ class ChunkedGraph(object):
             return {}
 
         range_read = self.table.read_rows(row_set=row_set, filter_=row_filter)
-        res = {v.row_key: partial_row_data_to_column_dict(v)
-               for v in range_read}
+        res = {v.row_key: partial_row_data_to_column_dict(v) for v in range_read}
         return res
 
-    def _execute_read(self, row_set: RowSet, row_filter: RowFilter = None) \
-            -> Dict[bytes, Dict[column_keys._Column, bigtable.row_data.PartialRowData]]:
-        """ Core function to read rows from Bigtable. Uses standard Bigtable retry logic
+    def _execute_read(
+        self, row_set: RowSet, row_filter: RowFilter = None
+    ) -> Dict[bytes, Dict[column_keys._Column, bigtable.row_data.PartialRowData]]:
+        """Core function to read rows from Bigtable. Uses standard Bigtable retry logic
         :param row_set: BigTable RowSet
         :param row_filter: BigTable RowFilter
         :return: Dict[bytes, Dict[column_keys._Column, bigtable.row_data.PartialRowData]]
@@ -1315,25 +1469,26 @@ class ChunkedGraph(object):
         # calculate this properly (range_read.request.SerializeToString()), but this estimate is
         # good enough for now
         max_row_key_count = 20000
-        n_subrequests = max(1, int(np.ceil(len(row_set.row_keys) /
-                                           max_row_key_count)))
+        n_subrequests = max(1, int(np.ceil(len(row_set.row_keys) / max_row_key_count)))
         n_threads = min(n_subrequests, 2 * mu.n_cpus)
 
         row_sets = []
         for i in range(n_subrequests):
             r = RowSet()
-            r.row_keys = row_set.row_keys[i * max_row_key_count:
-                                          (i + 1) * max_row_key_count]
+            r.row_keys = row_set.row_keys[
+                i * max_row_key_count : (i + 1) * max_row_key_count
+            ]
             row_sets.append(r)
 
         # Don't forget the original RowSet's row_ranges
         row_sets[0].row_ranges = row_set.row_ranges
 
-        responses = mu.multithread_func(self._execute_read_thread,
-                                        params=((r, row_filter)
-                                                for r in row_sets),
-                                        debug=n_threads == 1,
-                                        n_threads=n_threads)
+        responses = mu.multithread_func(
+            self._execute_read_thread,
+            params=((r, row_filter) for r in row_sets),
+            debug=n_threads == 1,
+            n_threads=n_threads,
+        )
 
         combined_response = {}
         for resp in responses:
@@ -1342,17 +1497,23 @@ class ChunkedGraph(object):
         return combined_response
 
     def range_read_chunk(
-            self,
-            layer: Optional[int] = None,
-            x: Optional[int] = None,
-            y: Optional[int] = None,
-            z: Optional[int] = None,
-            chunk_id: Optional[np.uint64] = None,
-            columns: Optional[Union[Iterable[column_keys._Column], column_keys._Column]] = None,
-            time_stamp: Optional[datetime.datetime] = None) -> Dict[np.uint64, Union[
-                Dict[column_keys._Column, List[bigtable.row_data.Cell]],
-                List[bigtable.row_data.Cell]
-            ]]:
+        self,
+        layer: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        z: Optional[int] = None,
+        chunk_id: Optional[np.uint64] = None,
+        columns: Optional[
+            Union[Iterable[column_keys._Column], column_keys._Column]
+        ] = None,
+        time_stamp: Optional[datetime.datetime] = None,
+    ) -> Dict[
+        np.uint64,
+        Union[
+            Dict[column_keys._Column, List[bigtable.row_data.Cell]],
+            List[bigtable.row_data.Cell],
+        ],
+    ]:
         """Convenience function for reading all NodeID rows of a single chunk from Bigtable.
         Chunk can either be specified by its (layer, x, y, and z coordinate), or by the chunk ID.
 
@@ -1389,7 +1550,9 @@ class ChunkedGraph(object):
         elif layer is not None and x is not None and y is not None and z is not None:
             chunk_id = self.get_chunk_id(layer=layer, x=x, y=y, z=z)
         else:
-            raise Exception("Either chunk_id or layer and coordinates have to be defined")
+            raise Exception(
+                "Either chunk_id or layer and coordinates have to be defined"
+            )
 
         if layer == 1:
             max_segment_id = self.get_segment_id_limit(chunk_id)
@@ -1407,15 +1570,17 @@ class ChunkedGraph(object):
                 end_id_inclusive=True,
                 columns=columns,
                 end_time=time_stamp,
-                end_time_inclusive=True)
+                end_time_inclusive=True,
+            )
         except Exception as err:
-            raise Exception("Unable to consume chunk read: "
-                            "[%d, %d, %d], l = %d: %s" %
-                            (x, y, z, layer, err))
+            raise Exception(
+                "Unable to consume chunk read: "
+                "[%d, %d, %d], l = %d: %s" % (x, y, z, layer, err)
+            )
         return rr
 
     def range_read_layer(self, layer_id: int):
-        """ Reads all ids within a layer
+        """Reads all ids within a layer
 
         This can take a while depending on the size of the graph
 
@@ -1424,20 +1589,19 @@ class ChunkedGraph(object):
         """
         raise NotImplementedError()
 
-    def test_if_nodes_are_in_same_chunk(self, node_ids: Sequence[np.uint64]
-                                        ) -> bool:
-        """ Test whether two nodes are in the same chunk
+    def test_if_nodes_are_in_same_chunk(self, node_ids: Sequence[np.uint64]) -> bool:
+        """Test whether two nodes are in the same chunk
 
         :param node_ids: list of two ints
         :return: bool
         """
         assert len(node_ids) == 2
-        return self.get_chunk_id(node_id=node_ids[0]) == \
-            self.get_chunk_id(node_id=node_ids[1])
+        return self.get_chunk_id(node_id=node_ids[0]) == self.get_chunk_id(
+            node_id=node_ids[1]
+        )
 
-    def get_chunk_id_from_coord(self, layer: int,
-                                x: int, y: int, z: int) -> np.uint64:
-        """ Return ChunkID for given chunked graph layer and voxel coordinates.
+    def get_chunk_id_from_coord(self, layer: int, x: int, y: int, z: int) -> np.uint64:
+        """Return ChunkID for given chunked graph layer and voxel coordinates.
 
         :param layer: int -- ChunkedGraph layer
         :param x: int -- X coordinate in voxel
@@ -1451,36 +1615,60 @@ class ChunkedGraph(object):
             layer=layer,
             x=x // (int(self.chunk_size[0]) * base_chunk_span),
             y=y // (int(self.chunk_size[1]) * base_chunk_span),
-            z=z // (int(self.chunk_size[2]) * base_chunk_span))
+            z=z // (int(self.chunk_size[2]) * base_chunk_span),
+        )
 
     def get_atomic_ids_from_coords(self, coordinates, parent_id=None, max_dist_nm=250):
-        """ Retrieves supervoxel ids for multiple coords."""
+        """Retrieves supervoxel ids for multiple coords."""
 
         assert self.get_chunk_layer(parent_id) > 1
 
         coordinates_nm = coordinates * np.array(self.cv.resolution)
-        parent_ts = self.read_node_id_row(parent_id)[column_keys.Hierarchy.Child][0].timestamp
+        parent_ts = self.read_node_id_row(parent_id)[column_keys.Hierarchy.Child][
+            0
+        ].timestamp
 
         max_dist_vx = np.ceil(max_dist_nm / self.cv.resolution).astype(dtype=np.int32)
 
-        bbox = np.array([np.min(coordinates, axis=0) - max_dist_vx, 
-                        np.max(coordinates, axis=0) + max_dist_vx + 1])
+        bbox = np.array(
+            [
+                np.min(coordinates, axis=0) - max_dist_vx,
+                np.max(coordinates, axis=0) + max_dist_vx + 1,
+            ]
+        )
 
-        local_sv_seg = self.cv[bbox[0, 0]: bbox[1, 0], bbox[0, 1]: bbox[1, 1], bbox[0, 2]: bbox[1, 2]].squeeze()
+        local_sv_seg = self.cv[
+            bbox[0, 0] : bbox[1, 0], bbox[0, 1] : bbox[1, 1], bbox[0, 2] : bbox[1, 2]
+        ].squeeze()
 
-        lower_bs = np.floor((np.array(coordinates_nm) - max_dist_nm) / np.array(self.cv.resolution) - bbox[0]).astype(np.int32)
-        upper_bs = np.ceil((np.array(coordinates_nm) + max_dist_nm) / np.array(self.cv.resolution) - bbox[0]).astype(np.int32)
+        lower_bs = np.floor(
+            (np.array(coordinates_nm) - max_dist_nm) / np.array(self.cv.resolution)
+            - bbox[0]
+        ).astype(np.int32)
+        upper_bs = np.ceil(
+            (np.array(coordinates_nm) + max_dist_nm) / np.array(self.cv.resolution)
+            - bbox[0]
+        ).astype(np.int32)
         local_sv_ids = []
         for lb, ub in zip(lower_bs, upper_bs):
-            local_sv_ids.extend(fastremap.unique(local_sv_seg[lb[0]: ub[0], lb[1]: ub[1], lb[2]: ub[2]]))
+            local_sv_ids.extend(
+                fastremap.unique(
+                    local_sv_seg[lb[0] : ub[0], lb[1] : ub[1], lb[2] : ub[2]]
+                )
+            )
         local_sv_ids = fastremap.unique(np.array(local_sv_ids, dtype=np.uint64))
 
-        local_parent_ids = self.get_roots(local_sv_ids, time_stamp=parent_ts,
-                                        stop_layer=self.get_chunk_layer(parent_id))
+        local_parent_ids = self.get_roots(
+            local_sv_ids,
+            time_stamp=parent_ts,
+            stop_layer=self.get_chunk_layer(parent_id),
+        )
 
-
-        local_parent_seg = fastremap.remap(local_sv_seg, dict(zip(local_sv_ids, local_parent_ids)),
-                                        preserve_missing_labels=True)
+        local_parent_seg = fastremap.remap(
+            local_sv_seg,
+            dict(zip(local_sv_ids, local_parent_ids)),
+            preserve_missing_labels=True,
+        )
 
         parent_id_locs_vx = np.array(np.where(local_parent_seg == parent_id)).T
 
@@ -1488,9 +1676,11 @@ class ChunkedGraph(object):
             self.logger.debug("Parent not found.")
             return None
 
-        parent_id_locs_nm = (parent_id_locs_vx + bbox[0])* np.array(self.cv.resolution)
+        parent_id_locs_nm = (parent_id_locs_vx + bbox[0]) * np.array(self.cv.resolution)
 
-        dist_mat = np.sqrt(np.sum((parent_id_locs_nm[:, None] - coordinates_nm)**2, axis=-1))
+        dist_mat = np.sqrt(
+            np.sum((parent_id_locs_nm[:, None] - coordinates_nm) ** 2, axis=-1)
+        )
         match_ids = np.argmin(dist_mat, axis=0)
         matched_dists = np.array([dist_mat[idx, i] for i, idx in enumerate(match_ids)])
 
@@ -1505,25 +1695,29 @@ class ChunkedGraph(object):
 
     def read_log_row(
         self, operation_id: np.uint64
-    ) -> Union[Dict[column_keys._Column, Union[np.ndarray, np.number]],
-               datetime.datetime]:
-        """ Retrieves log record from Bigtable for a given operation ID
+    ) -> Union[
+        Dict[column_keys._Column, Union[np.ndarray, np.number]], datetime.datetime
+    ]:
+        """Retrieves log record from Bigtable for a given operation ID
 
         :param operation_id: np.uint64
         :return: Dict[column_keys._Column, Union[np.ndarray, np.number]]
         """
         log_record = list(self.read_log_rows([operation_id]).values())[0]
-        
+
         if len(log_record) == 0:
             return {}, None
 
         return log_record, log_record["timestamp"]
 
-    def read_log_rows(self, operation_ids: Optional[Sequence] = None,
-            start_time: Optional[datetime.datetime] = None,
-            end_time: Optional[datetime.datetime] = None,
-            end_time_inclusive: bool = False):
-        """ Retrieves log records from Bigtable.
+    def read_log_rows(
+        self,
+        operation_ids: Optional[Sequence] = None,
+        start_time: Optional[datetime.datetime] = None,
+        end_time: Optional[datetime.datetime] = None,
+        end_time_inclusive: bool = False,
+    ):
+        """Retrieves log records from Bigtable.
 
         Keyword Arguments:
             operation_ids {Optional[datetime.datetime]} -- IDs of operations to limit to. If None,
@@ -1557,7 +1751,7 @@ class ChunkedGraph(object):
                 columns=columns,
                 start_time=start_time,
                 end_time=end_time,
-                end_time_inclusive=end_time_inclusive
+                end_time_inclusive=end_time_inclusive,
             )
         else:
             log_records_d = self.read_node_id_rows(
@@ -1565,7 +1759,7 @@ class ChunkedGraph(object):
                 columns=columns,
                 start_time=start_time,
                 end_time=end_time,
-                end_time_inclusive=end_time_inclusive
+                end_time_inclusive=end_time_inclusive,
             )
 
         if len(log_records_d) == 0:
@@ -1580,7 +1774,7 @@ class ChunkedGraph(object):
         return log_records_d
 
     def get_earliest_timestamp(self):
-        """ Retrieves timestamp of first edit
+        """Retrieves timestamp of first edit
 
         :return: None or dict
         """
@@ -1593,12 +1787,16 @@ class ChunkedGraph(object):
 
         return None
 
-    def add_atomic_edges_in_chunks(self, edge_id_dict: dict,
-                                   edge_aff_dict: dict, edge_area_dict: dict,
-                                   isolated_node_ids: Sequence[np.uint64],
-                                   verbose: bool = True,
-                                   time_stamp: Optional[datetime.datetime] = None):
-        """ Creates atomic nodes in first abstraction layer for a SINGLE chunk
+    def add_atomic_edges_in_chunks(
+        self,
+        edge_id_dict: dict,
+        edge_aff_dict: dict,
+        edge_area_dict: dict,
+        isolated_node_ids: Sequence[np.uint64],
+        verbose: bool = True,
+        time_stamp: Optional[datetime.datetime] = None,
+    ):
+        """Creates atomic nodes in first abstraction layer for a SINGLE chunk
             and all abstract nodes in the second for the same chunk
 
         Alle edges (edge_ids) need to be from one chunk and no nodes should
@@ -1621,13 +1819,21 @@ class ChunkedGraph(object):
             time_stamp = UTC.localize(time_stamp)
 
         # Comply to resolution of BigTables TimeRange
-        time_stamp = get_google_compatible_time_stamp(time_stamp,
-                                                      round_up=False)
+        time_stamp = get_google_compatible_time_stamp(time_stamp, round_up=False)
 
-        edge_id_keys = ["in_connected", "in_disconnected", "cross",
-                        "between_connected", "between_disconnected"]
-        edge_aff_keys = ["in_connected", "in_disconnected", "between_connected",
-                         "between_disconnected"]
+        edge_id_keys = [
+            "in_connected",
+            "in_disconnected",
+            "cross",
+            "between_connected",
+            "between_disconnected",
+        ]
+        edge_aff_keys = [
+            "in_connected",
+            "in_disconnected",
+            "between_connected",
+            "between_disconnected",
+        ]
 
         # Check if keys exist and include an empty array if not
         n_edge_ids = 0
@@ -1658,38 +1864,45 @@ class ChunkedGraph(object):
             chunk_id = self.get_chunk_id(isolated_node_ids[0])
 
         chunk_id_c = self.get_chunk_coordinates(chunk_id)
-        parent_chunk_id = self.get_chunk_id(layer=2, x=chunk_id_c[0],
-                                            y=chunk_id_c[1], z=chunk_id_c[2])
+        parent_chunk_id = self.get_chunk_id(
+            layer=2, x=chunk_id_c[0], y=chunk_id_c[1], z=chunk_id_c[2]
+        )
 
         # Get connected component within the chunk
-        chunk_node_ids = np.concatenate([
+        chunk_node_ids = np.concatenate(
+            [
                 isolated_node_ids.astype(np.uint64),
                 np.unique(edge_id_dict["in_connected"]),
                 np.unique(edge_id_dict["in_disconnected"]),
                 np.unique(edge_id_dict["cross"][:, 0]),
                 np.unique(edge_id_dict["between_connected"][:, 0]),
-                np.unique(edge_id_dict["between_disconnected"][:, 0])])
+                np.unique(edge_id_dict["between_disconnected"][:, 0]),
+            ]
+        )
 
         chunk_node_ids = np.unique(chunk_node_ids)
 
-        node_chunk_ids = np.array([self.get_chunk_id(c)
-                                   for c in chunk_node_ids],
-                                  dtype=np.uint64)
+        node_chunk_ids = np.array(
+            [self.get_chunk_id(c) for c in chunk_node_ids], dtype=np.uint64
+        )
 
-        u_node_chunk_ids, c_node_chunk_ids = np.unique(node_chunk_ids,
-                                                       return_counts=True)
+        u_node_chunk_ids, c_node_chunk_ids = np.unique(
+            node_chunk_ids, return_counts=True
+        )
         if len(u_node_chunk_ids) > 1:
-            raise Exception("%d: %d chunk ids found in node id list. "
-                            "Some edges might be in the wrong order. "
-                            "Number of occurences:" %
-                            (chunk_id, len(u_node_chunk_ids)), c_node_chunk_ids)
+            raise Exception(
+                "%d: %d chunk ids found in node id list. "
+                "Some edges might be in the wrong order. "
+                "Number of occurences:" % (chunk_id, len(u_node_chunk_ids)),
+                c_node_chunk_ids,
+            )
 
         add_edge_ids = np.vstack([chunk_node_ids, chunk_node_ids]).T
-        edge_ids = np.concatenate([edge_id_dict["in_connected"].copy(),
-                                   add_edge_ids])
+        edge_ids = np.concatenate([edge_id_dict["in_connected"].copy(), add_edge_ids])
 
         graph, _, _, unique_graph_ids = flatgraph_utils.build_gt_graph(
-            edge_ids, make_directed=True)
+            edge_ids, make_directed=True
+        )
 
         ccs = flatgraph_utils.connected_components(graph)
 
@@ -1745,11 +1958,15 @@ class ChunkedGraph(object):
                 # in chunk + connected
                 time_start_2 = time.time()
                 if node_id in remapping["in_connected"]:
-                    row_ids, column_ids = sparse_indices["in_connected"][remapping["in_connected"][node_id]]
+                    row_ids, column_ids = sparse_indices["in_connected"][
+                        remapping["in_connected"][node_id]
+                    ]
 
                     inv_column_ids = (column_ids + 1) % 2
 
-                    connected_ids = edge_id_dict["in_connected"][row_ids, inv_column_ids]
+                    connected_ids = edge_id_dict["in_connected"][
+                        row_ids, inv_column_ids
+                    ]
                     connected_affs = edge_aff_dict["in_connected"][row_ids]
                     connected_areas = edge_area_dict["in_connected"][row_ids]
                     time_dict["in_connected"].append(time.time() - time_start_2)
@@ -1761,10 +1978,14 @@ class ChunkedGraph(object):
 
                 # in chunk + disconnected
                 if node_id in remapping["in_disconnected"]:
-                    row_ids, column_ids = sparse_indices["in_disconnected"][remapping["in_disconnected"][node_id]]
+                    row_ids, column_ids = sparse_indices["in_disconnected"][
+                        remapping["in_disconnected"][node_id]
+                    ]
                     inv_column_ids = (column_ids + 1) % 2
 
-                    disconnected_ids = edge_id_dict["in_disconnected"][row_ids, inv_column_ids]
+                    disconnected_ids = edge_id_dict["in_disconnected"][
+                        row_ids, inv_column_ids
+                    ]
                     disconnected_affs = edge_aff_dict["in_disconnected"][row_ids]
                     disconnected_areas = edge_area_dict["in_disconnected"][row_ids]
                     time_dict["in_disconnected"].append(time.time() - time_start_2)
@@ -1776,7 +1997,9 @@ class ChunkedGraph(object):
 
                 # out chunk + connected
                 if node_id in remapping["between_connected"]:
-                    row_ids, column_ids = sparse_indices["between_connected"][remapping["between_connected"][node_id]]
+                    row_ids, column_ids = sparse_indices["between_connected"][
+                        remapping["between_connected"][node_id]
+                    ]
 
                     row_ids = row_ids[column_ids == 0]
                     column_ids = column_ids[column_ids == 0]
@@ -1784,35 +2007,69 @@ class ChunkedGraph(object):
                     time_dict["out_connected_mask"].append(time.time() - time_start_2)
                     time_start_2 = time.time()
 
-                    connected_ids = np.concatenate([connected_ids, edge_id_dict["between_connected"][row_ids, inv_column_ids]])
-                    connected_affs = np.concatenate([connected_affs, edge_aff_dict["between_connected"][row_ids]])
-                    connected_areas = np.concatenate([connected_areas, edge_area_dict["between_connected"][row_ids]])
+                    connected_ids = np.concatenate(
+                        [
+                            connected_ids,
+                            edge_id_dict["between_connected"][row_ids, inv_column_ids],
+                        ]
+                    )
+                    connected_affs = np.concatenate(
+                        [connected_affs, edge_aff_dict["between_connected"][row_ids]]
+                    )
+                    connected_areas = np.concatenate(
+                        [connected_areas, edge_area_dict["between_connected"][row_ids]]
+                    )
 
-                    parent_cross_edges = np.concatenate([parent_cross_edges, edge_id_dict["between_connected"][row_ids]])
+                    parent_cross_edges = np.concatenate(
+                        [parent_cross_edges, edge_id_dict["between_connected"][row_ids]]
+                    )
 
                     time_dict["out_connected"].append(time.time() - time_start_2)
                     time_start_2 = time.time()
 
                 # out chunk + disconnected
                 if node_id in remapping["between_disconnected"]:
-                    row_ids, column_ids = sparse_indices["between_disconnected"][remapping["between_disconnected"][node_id]]
+                    row_ids, column_ids = sparse_indices["between_disconnected"][
+                        remapping["between_disconnected"][node_id]
+                    ]
 
                     row_ids = row_ids[column_ids == 0]
                     column_ids = column_ids[column_ids == 0]
                     inv_column_ids = (column_ids + 1) % 2
-                    time_dict["out_disconnected_mask"].append(time.time() - time_start_2)
+                    time_dict["out_disconnected_mask"].append(
+                        time.time() - time_start_2
+                    )
                     time_start_2 = time.time()
 
-                    disconnected_ids = np.concatenate([disconnected_ids, edge_id_dict["between_disconnected"][row_ids, inv_column_ids]])
-                    disconnected_affs = np.concatenate([disconnected_affs, edge_aff_dict["between_disconnected"][row_ids]])
-                    disconnected_areas = np.concatenate([disconnected_areas, edge_area_dict["between_disconnected"][row_ids]])
+                    disconnected_ids = np.concatenate(
+                        [
+                            disconnected_ids,
+                            edge_id_dict["between_disconnected"][
+                                row_ids, inv_column_ids
+                            ],
+                        ]
+                    )
+                    disconnected_affs = np.concatenate(
+                        [
+                            disconnected_affs,
+                            edge_aff_dict["between_disconnected"][row_ids],
+                        ]
+                    )
+                    disconnected_areas = np.concatenate(
+                        [
+                            disconnected_areas,
+                            edge_area_dict["between_disconnected"][row_ids],
+                        ]
+                    )
 
                     time_dict["out_disconnected"].append(time.time() - time_start_2)
                     time_start_2 = time.time()
 
                 # cross
                 if node_id in remapping["cross"]:
-                    row_ids, column_ids = sparse_indices["cross"][remapping["cross"][node_id]]
+                    row_ids, column_ids = sparse_indices["cross"][
+                        remapping["cross"][node_id]
+                    ]
 
                     row_ids = row_ids[column_ids == 0]
                     column_ids = column_ids[column_ids == 0]
@@ -1820,11 +2077,22 @@ class ChunkedGraph(object):
                     time_dict["cross_mask"].append(time.time() - time_start_2)
                     time_start_2 = time.time()
 
-                    connected_ids = np.concatenate([connected_ids, edge_id_dict["cross"][row_ids, inv_column_ids]])
-                    connected_affs = np.concatenate([connected_affs, np.full((len(row_ids)), np.inf, dtype=np.float32)])
-                    connected_areas = np.concatenate([connected_areas, np.ones((len(row_ids)), dtype=np.uint64)])
+                    connected_ids = np.concatenate(
+                        [connected_ids, edge_id_dict["cross"][row_ids, inv_column_ids]]
+                    )
+                    connected_affs = np.concatenate(
+                        [
+                            connected_affs,
+                            np.full((len(row_ids)), np.inf, dtype=np.float32),
+                        ]
+                    )
+                    connected_areas = np.concatenate(
+                        [connected_areas, np.ones((len(row_ids)), dtype=np.uint64)]
+                    )
 
-                    parent_cross_edges = np.concatenate([parent_cross_edges, edge_id_dict["cross"][row_ids]])
+                    parent_cross_edges = np.concatenate(
+                        [parent_cross_edges, edge_id_dict["cross"][row_ids]]
+                    )
                     time_dict["cross"].append(time.time() - time_start_2)
                     time_start_2 = time.time()
 
@@ -1834,22 +2102,33 @@ class ChunkedGraph(object):
                 areas = np.concatenate([connected_areas, disconnected_areas])
                 connected = np.arange(len(connected_ids), dtype=np.int)
 
-                val_dict = {column_keys.Connectivity.Partner: partners,
-                            column_keys.Connectivity.Affinity: affinities,
-                            column_keys.Connectivity.Area: areas,
-                            column_keys.Connectivity.Connected: connected,
-                            column_keys.Hierarchy.Parent: parent_id}
+                val_dict = {
+                    column_keys.Connectivity.Partner: partners,
+                    column_keys.Connectivity.Affinity: affinities,
+                    column_keys.Connectivity.Area: areas,
+                    column_keys.Connectivity.Connected: connected,
+                    column_keys.Hierarchy.Parent: parent_id,
+                }
 
-                rows.append(self.mutate_row(serializers.serialize_uint64(node_id),
-                                            val_dict, time_stamp=time_stamp))
+                rows.append(
+                    self.mutate_row(
+                        serializers.serialize_uint64(node_id),
+                        val_dict,
+                        time_stamp=time_stamp,
+                    )
+                )
                 node_c += 1
                 time_dict["creating_lv1_row"].append(time.time() - time_start_2)
 
             time_start_1 = time.time()
             # Create parent node
-            rows.append(self.mutate_row(serializers.serialize_uint64(parent_id),
-                                        {column_keys.Hierarchy.Child: node_ids},
-                                        time_stamp=time_stamp))
+            rows.append(
+                self.mutate_row(
+                    serializers.serialize_uint64(parent_id),
+                    {column_keys.Hierarchy.Child: node_ids},
+                    time_stamp=time_stamp,
+                )
+            )
 
             time_dict["creating_lv2_row"].append(time.time() - time_start_1)
             time_start_1 = time.time()
@@ -1862,12 +2141,18 @@ class ChunkedGraph(object):
                 layer_cross_edges = parent_cross_edges[cce_layers == cc_layer]
 
                 if len(layer_cross_edges) > 0:
-                    val_dict[column_keys.Connectivity.CrossChunkEdge[cc_layer]] = \
-                        layer_cross_edges
+                    val_dict[
+                        column_keys.Connectivity.CrossChunkEdge[cc_layer]
+                    ] = layer_cross_edges
 
             if len(val_dict) > 0:
-                rows.append(self.mutate_row(serializers.serialize_uint64(parent_id),
-                                            val_dict, time_stamp=time_stamp))
+                rows.append(
+                    self.mutate_row(
+                        serializers.serialize_uint64(parent_id),
+                        val_dict,
+                        time_stamp=time_stamp,
+                    )
+                )
             node_c += 1
 
             time_dict["adding_cross_edges"].append(time.time() - time_start_1)
@@ -1883,19 +2168,31 @@ class ChunkedGraph(object):
             time_dict["writing"].append(time.time() - time_start_1)
 
         if verbose:
-            self.logger.debug("Time creating rows: %.3fs for %d ccs with %d nodes" %
-                              (time.time() - time_start, len(ccs), node_c))
+            self.logger.debug(
+                "Time creating rows: %.3fs for %d ccs with %d nodes"
+                % (time.time() - time_start, len(ccs), node_c)
+            )
 
             for k in time_dict.keys():
-                self.logger.debug("%s -- %.3fms for %d instances -- avg = %.3fms" %
-                                  (k, np.sum(time_dict[k])*1000, len(time_dict[k]),
-                                   np.mean(time_dict[k])*1000))
+                self.logger.debug(
+                    "%s -- %.3fms for %d instances -- avg = %.3fms"
+                    % (
+                        k,
+                        np.sum(time_dict[k]) * 1000,
+                        len(time_dict[k]),
+                        np.mean(time_dict[k]) * 1000,
+                    )
+                )
 
-    def add_layer(self, layer_id: int,
-                  child_chunk_coords: Sequence[Sequence[int]],
-                  time_stamp: Optional[datetime.datetime] = None,
-                  verbose: bool = True, n_threads: int = 20) -> None:
-        """ Creates the abstract nodes for a given chunk in a given layer
+    def add_layer(
+        self,
+        layer_id: int,
+        child_chunk_coords: Sequence[Sequence[int]],
+        time_stamp: Optional[datetime.datetime] = None,
+        verbose: bool = True,
+        n_threads: int = 20,
+    ) -> None:
+        """Creates the abstract nodes for a given chunk in a given layer
 
         :param layer_id: int
         :param child_chunk_coords: int array of length 3
@@ -1904,15 +2201,16 @@ class ChunkedGraph(object):
         :param verbose: bool
         :param n_threads: int
         """
+
         def _read_subchunks_thread(chunk_coord):
             # Get start and end key
             x, y, z = chunk_coord
 
-            columns = [column_keys.Hierarchy.Child] + \
-                      [column_keys.Connectivity.CrossChunkEdge[l]
-                       for l in range(layer_id - 1, self.n_layers)]
-            range_read = self.range_read_chunk(layer_id - 1, x, y, z,
-                                               columns=columns)
+            columns = [column_keys.Hierarchy.Child] + [
+                column_keys.Connectivity.CrossChunkEdge[l]
+                for l in range(layer_id - 1, self.n_layers)
+            ]
+            range_read = self.range_read_chunk(layer_id - 1, x, y, z, columns=columns)
 
             # Due to restarted jobs some nodes in the layer below might be
             # duplicated. We want to ignore the earlier created node(s) because
@@ -1932,8 +2230,11 @@ class ChunkedGraph(object):
             for row_id, row_data in range_read.items():
                 segment_id = self.get_segment_id(row_id)
 
-                cross_edge_columns = {k: v for (k, v) in row_data.items()
-                                      if k.family_id == self.cross_edge_family_id}
+                cross_edge_columns = {
+                    k: v
+                    for (k, v) in row_data.items()
+                    if k.family_id == self.cross_edge_family_id
+                }
                 if cross_edge_columns:
                     row_cell_dict[row_id] = cross_edge_columns
 
@@ -1952,8 +2253,7 @@ class ChunkedGraph(object):
             max_child_ids = max_child_ids[sorting]
 
             counter = collections.defaultdict(int)
-            max_child_ids_occ_so_far = np.zeros(len(max_child_ids),
-                                                dtype=np.int)
+            max_child_ids_occ_so_far = np.zeros(len(max_child_ids), dtype=np.int)
             for i_row in range(len(max_child_ids)):
                 max_child_ids_occ_so_far[i_row] = counter[max_child_ids[i_row]]
                 counter[max_child_ids[i_row]] += 1
@@ -1979,29 +2279,34 @@ class ChunkedGraph(object):
                         atomic_cross_edges = cross_edge_dict[row_id][layer_id - 1]
 
                         if len(atomic_cross_edges) > 0:
-                            atomic_partner_id_dict[row_id] = \
-                                atomic_cross_edges[:, 1]
+                            atomic_partner_id_dict[row_id] = atomic_cross_edges[:, 1]
 
-                            new_pairs = zip(atomic_cross_edges[:, 0],
-                                            [row_id] * len(atomic_cross_edges))
+                            new_pairs = zip(
+                                atomic_cross_edges[:, 0],
+                                [row_id] * len(atomic_cross_edges),
+                            )
                             atomic_child_id_dict_pairs.extend(new_pairs)
 
         def _resolve_cross_chunk_edges_thread(args) -> None:
             start, end = args
 
-            for i_child_key, child_key in\
-                    enumerate(atomic_partner_id_dict_keys[start: end]):
+            for i_child_key, child_key in enumerate(
+                atomic_partner_id_dict_keys[start:end]
+            ):
                 this_atomic_partner_ids = atomic_partner_id_dict[child_key]
 
-                partners = {atomic_child_id_dict[atomic_cross_id]
-                            for atomic_cross_id in this_atomic_partner_ids
-                            if atomic_child_id_dict[atomic_cross_id] != 0}
+                partners = {
+                    atomic_child_id_dict[atomic_cross_id]
+                    for atomic_cross_id in this_atomic_partner_ids
+                    if atomic_child_id_dict[atomic_cross_id] != 0
+                }
 
                 if len(partners) > 0:
                     partners = np.array(list(partners), dtype=np.uint64)[:, None]
 
-                    this_ids = np.array([child_key] * len(partners),
-                                        dtype=np.uint64)[:, None]
+                    this_ids = np.array([child_key] * len(partners), dtype=np.uint64)[
+                        :, None
+                    ]
                     these_edges = np.concatenate([this_ids, partners], axis=1)
 
                     edge_ids.extend(these_edges)
@@ -2012,7 +2317,7 @@ class ChunkedGraph(object):
             # Collect cc info
             parent_layer_ids = range(layer_id, self.n_layers + 1)
             cc_connections = {l: [] for l in parent_layer_ids}
-            for i_cc, cc in enumerate(ccs[start: end]):
+            for i_cc, cc in enumerate(ccs[start:end]):
                 node_ids = unique_graph_ids[cc]
 
                 parent_cross_edges = collections.defaultdict(list)
@@ -2022,19 +2327,21 @@ class ChunkedGraph(object):
                     if node_id in cross_edge_dict:
                         # Extract edges relevant to this node
                         for l in range(layer_id, self.n_layers):
-                            if l in cross_edge_dict[node_id] and \
-                                    len(cross_edge_dict[node_id][l]) > 0:
-                                parent_cross_edges[l].append(cross_edge_dict[node_id][l])
+                            if (
+                                l in cross_edge_dict[node_id]
+                                and len(cross_edge_dict[node_id][l]) > 0
+                            ):
+                                parent_cross_edges[l].append(
+                                    cross_edge_dict[node_id][l]
+                                )
 
                 if self.use_skip_connections and len(node_ids) == 1:
                     for l in parent_layer_ids:
                         if l == self.n_layers or len(parent_cross_edges[l]) > 0:
-                            cc_connections[l].append([node_ids,
-                                                      parent_cross_edges])
+                            cc_connections[l].append([node_ids, parent_cross_edges])
                             break
                 else:
-                    cc_connections[layer_id].append([node_ids,
-                                                     parent_cross_edges])
+                    cc_connections[layer_id].append([node_ids, parent_cross_edges])
 
             # Write out cc info
             rows = []
@@ -2046,7 +2353,8 @@ class ChunkedGraph(object):
 
                 parent_chunk_id = parent_chunk_id_dict[parent_layer_id]
                 reserved_parent_ids = self.get_unique_node_id_range(
-                    parent_chunk_id, step=len(cc_connections[parent_layer_id]))
+                    parent_chunk_id, step=len(cc_connections[parent_layer_id])
+                )
 
                 for i_cc, cc_info in enumerate(cc_connections[parent_layer_id]):
                     node_ids, parent_cross_edges = cc_info
@@ -2055,19 +2363,28 @@ class ChunkedGraph(object):
                     val_dict = {column_keys.Hierarchy.Parent: parent_id}
 
                     for node_id in node_ids:
-                        rows.append(self.mutate_row(
-                            serializers.serialize_uint64(node_id),
-                            val_dict, time_stamp=time_stamp))
+                        rows.append(
+                            self.mutate_row(
+                                serializers.serialize_uint64(node_id),
+                                val_dict,
+                                time_stamp=time_stamp,
+                            )
+                        )
 
                     val_dict = {column_keys.Hierarchy.Child: node_ids}
                     for l in range(parent_layer_id, self.n_layers):
                         if l in parent_cross_edges and len(parent_cross_edges[l]) > 0:
-                            val_dict[column_keys.Connectivity.CrossChunkEdge[l]] = \
-                                np.concatenate(parent_cross_edges[l])
+                            val_dict[
+                                column_keys.Connectivity.CrossChunkEdge[l]
+                            ] = np.concatenate(parent_cross_edges[l])
 
                     rows.append(
-                        self.mutate_row(serializers.serialize_uint64(parent_id),
-                                        val_dict, time_stamp=time_stamp))
+                        self.mutate_row(
+                            serializers.serialize_uint64(parent_id),
+                            val_dict,
+                            time_stamp=time_stamp,
+                        )
+                    )
 
                     if len(rows) > 100000:
                         self.bulk_write(rows)
@@ -2083,8 +2400,7 @@ class ChunkedGraph(object):
             time_stamp = UTC.localize(time_stamp)
 
         # Comply to resolution of BigTables TimeRange
-        time_stamp = get_google_compatible_time_stamp(time_stamp,
-                                                      round_up=False)
+        time_stamp = get_google_compatible_time_stamp(time_stamp, round_up=False)
 
         # 1 --------------------------------------------------------------------
         # The first part is concerned with reading data from the child nodes
@@ -2101,46 +2417,50 @@ class ChunkedGraph(object):
         n_jobs = np.min([n_threads, len(multi_args)])
 
         if n_jobs > 0:
-            mu.multithread_func(_read_subchunks_thread, multi_args,
-                                n_threads=n_jobs)
+            mu.multithread_func(_read_subchunks_thread, multi_args, n_threads=n_jobs)
 
         d = dict(atomic_child_id_dict_pairs)
         atomic_child_id_dict = collections.defaultdict(np.uint64, d)
         ll_node_ids = np.array(ll_node_ids, dtype=np.uint64)
 
         if verbose:
-            self.logger.debug("Time iterating through subchunks: %.3fs" %
-                              (time.time() - time_start))
+            self.logger.debug(
+                "Time iterating through subchunks: %.3fs" % (time.time() - time_start)
+            )
         time_start = time.time()
 
         # Extract edges from remaining cross chunk edges
         # and maintain unused cross chunk edges
         edge_ids = []
         # u_atomic_child_ids = np.unique(atomic_child_ids)
-        atomic_partner_id_dict_keys = \
-            np.array(list(atomic_partner_id_dict.keys()), dtype=np.uint64)
+        atomic_partner_id_dict_keys = np.array(
+            list(atomic_partner_id_dict.keys()), dtype=np.uint64
+        )
 
         if n_threads > 1:
-            n_jobs = n_threads * 3 # Heuristic
+            n_jobs = n_threads * 3  # Heuristic
         else:
             n_jobs = 1
 
         n_jobs = np.min([n_jobs, len(atomic_partner_id_dict_keys)])
 
         if n_jobs > 0:
-            spacing = np.linspace(0, len(atomic_partner_id_dict_keys),
-                                  n_jobs+1).astype(np.int)
+            spacing = np.linspace(
+                0, len(atomic_partner_id_dict_keys), n_jobs + 1
+            ).astype(np.int)
             starts = spacing[:-1]
             ends = spacing[1:]
 
             multi_args = list(zip(starts, ends))
 
-            mu.multithread_func(_resolve_cross_chunk_edges_thread, multi_args,
-                                n_threads=n_threads)
+            mu.multithread_func(
+                _resolve_cross_chunk_edges_thread, multi_args, n_threads=n_threads
+            )
 
         if verbose:
-            self.logger.debug("Time resolving cross chunk edges: %.3fs" %
-                              (time.time() - time_start))
+            self.logger.debug(
+                "Time resolving cross chunk edges: %.3fs" % (time.time() - time_start)
+            )
         time_start = time.time()
 
         # 2 --------------------------------------------------------------------
@@ -2160,40 +2480,46 @@ class ChunkedGraph(object):
         edge_ids.extend(add_edge_ids)
 
         graph, _, _, unique_graph_ids = flatgraph_utils.build_gt_graph(
-            edge_ids, make_directed=True)
+            edge_ids, make_directed=True
+        )
 
         ccs = flatgraph_utils.connected_components(graph)
 
         if verbose:
-            self.logger.debug("Time connected components: %.3fs" %
-                              (time.time() - time_start))
+            self.logger.debug(
+                "Time connected components: %.3fs" % (time.time() - time_start)
+            )
         time_start = time.time()
 
         # Add rows for nodes that are in this chunk
         # a connected component at a time
         if n_threads > 1:
-            n_jobs = n_threads * 3 # Heuristic
+            n_jobs = n_threads * 3  # Heuristic
         else:
             n_jobs = 1
 
         n_jobs = np.min([n_jobs, len(ccs)])
 
-        spacing = np.linspace(0, len(ccs), n_jobs+1).astype(np.int)
+        spacing = np.linspace(0, len(ccs), n_jobs + 1).astype(np.int)
         starts = spacing[:-1]
         ends = spacing[1:]
 
         multi_args = list(zip(starts, ends))
 
-        mu.multithread_func(_write_out_connected_components, multi_args,
-                            n_threads=n_threads)
+        mu.multithread_func(
+            _write_out_connected_components, multi_args, n_threads=n_threads
+        )
 
         if verbose:
-            self.logger.debug("Time writing %d connected components in layer %d: %.3fs" %
-                              (len(ccs), layer_id, time.time() - time_start))
+            self.logger.debug(
+                "Time writing %d connected components in layer %d: %.3fs"
+                % (len(ccs), layer_id, time.time() - time_start)
+            )
 
-    def get_atomic_cross_edge_dict(self, node_id: np.uint64,
-                                   layer_ids: Sequence[int] = None):
-        """ Extracts all atomic cross edges and serves them as a dictionary
+    def get_atomic_cross_edge_dict(
+        self, node_id: np.uint64, layer_ids: Sequence[int] = None
+    ):
+        """Extracts all atomic cross edges and serves them as a dictionary
 
         :param node_id: np.uint64
         :param layer_ids: list of ints
@@ -2227,10 +2553,13 @@ class ChunkedGraph(object):
 
         return atomic_cross_edges
 
-    def get_parents(self, node_ids: Sequence[np.uint64],
-                    get_only_relevant_parents: bool = True,
-                    time_stamp: Optional[datetime.datetime] = None):
-        """ Acquires parents of a node at a specific time stamp
+    def get_parents(
+        self,
+        node_ids: Sequence[np.uint64],
+        get_only_relevant_parents: bool = True,
+        time_stamp: Optional[datetime.datetime] = None,
+    ):
+        """Acquires parents of a node at a specific time stamp
 
         :param node_ids: list of uint64
         :param get_only_relevant_parents: bool
@@ -2246,30 +2575,32 @@ class ChunkedGraph(object):
         if time_stamp.tzinfo is None:
             time_stamp = UTC.localize(time_stamp)
 
-        parent_rows = self.read_node_id_rows(node_ids=node_ids,
-                                            columns=column_keys.Hierarchy.Parent,
-                                            end_time=time_stamp,
-                                            end_time_inclusive=True)
+        parent_rows = self.read_node_id_rows(
+            node_ids=node_ids,
+            columns=column_keys.Hierarchy.Parent,
+            end_time=time_stamp,
+            end_time_inclusive=True,
+        )
 
         if not parent_rows:
             return None
 
         if get_only_relevant_parents:
-            return np.array([parent_rows[node_id][0].value
-                             for node_id in node_ids])
+            return np.array([parent_rows[node_id][0].value for node_id in node_ids])
 
         parents = []
         for node_id in node_ids:
-            parents.append([(p.value, p.timestamp)
-                            for p in parent_rows[node_id]])
+            parents.append([(p.value, p.timestamp) for p in parent_rows[node_id]])
 
         return parents
 
-    def get_parent(self, node_id: np.uint64,
-                   get_only_relevant_parent: bool = True,
-                   time_stamp: Optional[datetime.datetime] = None) -> Union[
-                       List[Tuple[np.uint64, datetime.datetime]], np.uint64]:
-        """ Acquires parent of a node at a specific time stamp
+    def get_parent(
+        self,
+        node_id: np.uint64,
+        get_only_relevant_parent: bool = True,
+        time_stamp: Optional[datetime.datetime] = None,
+    ) -> Union[List[Tuple[np.uint64, datetime.datetime]], np.uint64]:
+        """Acquires parent of a node at a specific time stamp
 
         :param node_id: uint64
         :param get_only_relevant_parent: bool
@@ -2285,10 +2616,12 @@ class ChunkedGraph(object):
         if time_stamp.tzinfo is None:
             time_stamp = UTC.localize(time_stamp)
 
-        parents = self.read_node_id_row(node_id,
-                                        columns=column_keys.Hierarchy.Parent,
-                                        end_time=time_stamp,
-                                        end_time_inclusive=True)
+        parents = self.read_node_id_row(
+            node_id,
+            columns=column_keys.Hierarchy.Parent,
+            end_time=time_stamp,
+            end_time_inclusive=True,
+        )
 
         if not parents:
             return None
@@ -2298,8 +2631,9 @@ class ChunkedGraph(object):
 
         return [(p.value, p.timestamp) for p in parents]
 
-    def get_children(self, node_id: Union[Iterable[np.uint64], np.uint64],
-                     flatten: bool = False) -> Union[Dict[np.uint64, np.ndarray], np.ndarray]:
+    def get_children(
+        self, node_id: Union[Iterable[np.uint64], np.uint64], flatten: bool = False
+    ) -> Union[Dict[np.uint64, np.ndarray], np.ndarray]:
         """Returns children for the specified NodeID or NodeIDs
 
         :param node_id: The NodeID or NodeIDs for which to retrieve children
@@ -2312,38 +2646,51 @@ class ChunkedGraph(object):
         :rtype: Union[Dict[np.uint64, np.ndarray], np.ndarray]
         """
         if np.isscalar(node_id):
-            children = self.read_node_id_row(node_id=node_id, columns=column_keys.Hierarchy.Child)
+            children = self.read_node_id_row(
+                node_id=node_id, columns=column_keys.Hierarchy.Child
+            )
             if not children:
                 return np.empty(0, dtype=basetypes.NODE_ID)
             return children[0].value
         else:
-            children = self.read_node_id_rows(node_ids=node_id, columns=column_keys.Hierarchy.Child)
+            children = self.read_node_id_rows(
+                node_ids=node_id, columns=column_keys.Hierarchy.Child
+            )
             if flatten:
                 if not children:
                     return np.empty(0, dtype=basetypes.NODE_ID)
                 return np.concatenate([x[0].value for x in children.values()])
-            return {x: children[x][0].value
-                       if x in children else np.empty(0, dtype=basetypes.NODE_ID)
-                    for x in node_id}
+            return {
+                x: children[x][0].value
+                if x in children
+                else np.empty(0, dtype=basetypes.NODE_ID)
+                for x in node_id
+            }
 
-    def get_latest_roots(self, time_stamp: Optional[datetime.datetime] = get_max_time(),
-                         n_threads: int = 1) -> Sequence[np.uint64]:
-        """ Reads _all_ root ids
+    def get_latest_roots(
+        self,
+        time_stamp: Optional[datetime.datetime] = get_max_time(),
+        n_threads: int = 1,
+    ) -> Sequence[np.uint64]:
+        """Reads _all_ root ids
 
         :param time_stamp: datetime.datetime
         :param n_threads: int
         :return: array of np.uint64
         """
 
-        return chunkedgraph_comp.get_latest_roots(self, time_stamp=time_stamp,
-                                                  n_threads=n_threads)
+        return chunkedgraph_comp.get_latest_roots(
+            self, time_stamp=time_stamp, n_threads=n_threads
+        )
 
-    def get_delta_roots(self,
-                        time_stamp_start: datetime.datetime,
-                        time_stamp_end: Optional[datetime.datetime] = None,
-                        min_seg_id: int =1,
-                        n_threads: int = 1) -> Sequence[np.uint64]:
-        """ Returns root ids that have expired or have been created between two timestamps
+    def get_delta_roots(
+        self,
+        time_stamp_start: datetime.datetime,
+        time_stamp_end: Optional[datetime.datetime] = None,
+        min_seg_id: int = 1,
+        n_threads: int = 1,
+    ) -> Sequence[np.uint64]:
+        """Returns root ids that have expired or have been created between two timestamps
 
         :param time_stamp_start: datetime.datetime
             starting timestamp to return deltas from
@@ -2360,16 +2707,23 @@ class ChunkedGraph(object):
             but before time_stamp_end.
         """
 
-        return chunkedgraph_comp.get_delta_roots(self, time_stamp_start=time_stamp_start,
-                                                  time_stamp_end=time_stamp_end,
-                                                  min_seg_id=min_seg_id,
-                                                  n_threads=n_threads)
+        return chunkedgraph_comp.get_delta_roots(
+            self,
+            time_stamp_start=time_stamp_start,
+            time_stamp_end=time_stamp_end,
+            min_seg_id=min_seg_id,
+            n_threads=n_threads,
+        )
 
-    def get_roots(self, node_ids: Sequence[np.uint64],
-                  time_stamp: Optional[datetime.datetime] = None,
-                  stop_layer: int = None, n_tries: int = 1,
-                  assert_roots: bool = False):
-        """ Takes node ids and returns the associated agglomeration ids
+    def get_roots(
+        self,
+        node_ids: Sequence[np.uint64],
+        time_stamp: Optional[datetime.datetime] = None,
+        stop_layer: int = None,
+        n_tries: int = 1,
+        assert_roots: bool = False,
+    ):
+        """Takes node ids and returns the associated agglomeration ids
 
         :param node_ids: list of uint64
         :param time_stamp: None or datetime
@@ -2382,12 +2736,11 @@ class ChunkedGraph(object):
             time_stamp = UTC.localize(time_stamp)
 
         # Comply to resolution of BigTables TimeRange
-        time_stamp = get_google_compatible_time_stamp(time_stamp,
-                                                      round_up=False)
+        time_stamp = get_google_compatible_time_stamp(time_stamp, round_up=False)
 
         stop_layer = self.n_layers if not stop_layer else min(self.n_layers, stop_layer)
         layer_mask = np.ones(len(node_ids), dtype=np.bool)
-        
+
         for _ in range(n_tries):
             layer_mask[self.get_chunk_layers(node_ids) >= stop_layer] = False
             parent_ids = np.array(node_ids, dtype=basetypes.NODE_ID)
@@ -2410,14 +2763,22 @@ class ChunkedGraph(object):
         # that have failed to get to the stop layer as if we want to assert_roots
         # then we should fail that assertion
         if assert_roots:
-            raise(cg_exceptions.ChunkedGraphError(f'get_roots failed to get to stop_layer {stop_layer} for all node_ids: {parent_ids}'))
+            raise (
+                cg_exceptions.ChunkedGraphError(
+                    f"get_roots failed to get to stop_layer {stop_layer} for all node_ids: {parent_ids}"
+                )
+            )
         return parent_ids
 
-    def get_root(self, node_id: np.uint64,
-                 time_stamp: Optional[datetime.datetime] = None,
-                 get_all_parents=False, stop_layer: int = None,
-                 n_tries: int = 1) -> Union[List[np.uint64], np.uint64]:
-        """ Takes a node id and returns the associated agglomeration ids
+    def get_root(
+        self,
+        node_id: np.uint64,
+        time_stamp: Optional[datetime.datetime] = None,
+        get_all_parents=False,
+        stop_layer: int = None,
+        n_tries: int = 1,
+    ) -> Union[List[np.uint64], np.uint64]:
+        """Takes a node id and returns the associated agglomeration ids
 
         :param node_id: uint64
         :param time_stamp: None or datetime
@@ -2430,8 +2791,7 @@ class ChunkedGraph(object):
             time_stamp = UTC.localize(time_stamp)
 
         # Comply to resolution of BigTables TimeRange
-        time_stamp = get_google_compatible_time_stamp(time_stamp,
-                                                      round_up=False)
+        time_stamp = get_google_compatible_time_stamp(time_stamp, round_up=False)
 
         parent_id = node_id
         all_parent_ids = []
@@ -2444,11 +2804,9 @@ class ChunkedGraph(object):
         for i_try in range(n_tries):
             parent_id = node_id
 
-            for i_layer in range(self.get_chunk_layer(node_id),
-                                 int(stop_layer + 1)):
+            for i_layer in range(self.get_chunk_layer(node_id), int(stop_layer + 1)):
 
-                temp_parent_id = self.get_parent(parent_id,
-                                                 time_stamp=time_stamp)
+                temp_parent_id = self.get_parent(parent_id, time_stamp=time_stamp)
 
                 if temp_parent_id is None:
                     break
@@ -2462,36 +2820,40 @@ class ChunkedGraph(object):
             if self.get_chunk_layer(parent_id) >= stop_layer:
                 break
             else:
-                time.sleep(.5)
+                time.sleep(0.5)
 
         if self.get_chunk_layer(parent_id) < stop_layer:
-            raise Exception("Cannot find root id {}, {}".format(node_id,
-                                                                time_stamp))
+            raise Exception("Cannot find root id {}, {}".format(node_id, time_stamp))
 
         if get_all_parents:
             return np.array(all_parent_ids)
         else:
             return parent_id
 
-    def get_all_parents_dict(self, node_id: np.uint64,
-                             time_stamp: Optional[datetime.datetime] = None
-                             ) -> dict:
-        """ Takes a node id and returns all parents and parents' parents up to
+    def get_all_parents_dict(
+        self, node_id: np.uint64, time_stamp: Optional[datetime.datetime] = None
+    ) -> dict:
+        """Takes a node id and returns all parents and parents' parents up to
             the top
 
         :param node_id: uint64
         :param time_stamp: None or datetime
         :return: dict
         """
-        parent_ids = self.get_root(node_id=node_id, time_stamp=time_stamp,
-                                   get_all_parents=True)
+        parent_ids = self.get_root(
+            node_id=node_id, time_stamp=time_stamp, get_all_parents=True
+        )
         parent_id_layers = self.get_chunk_layers(parent_ids)
         return dict(zip(parent_id_layers, parent_ids))
 
-    def lock_root_loop(self, root_ids: Sequence[np.uint64],
-                       operation_id: np.uint64, max_tries: int = 1,
-                       waittime_s: float = 0.5) -> Tuple[bool, np.ndarray]:
-        """ Attempts to lock multiple roots at the same time
+    def lock_root_loop(
+        self,
+        root_ids: Sequence[np.uint64],
+        operation_id: np.uint64,
+        max_tries: int = 1,
+        waittime_s: float = 0.5,
+    ) -> Tuple[bool, np.ndarray]:
+        """Attempts to lock multiple roots at the same time
 
         :param root_ids: list of uint64
         :param operation_id: uint64
@@ -2520,10 +2882,11 @@ class ChunkedGraph(object):
 
             for i_root_id in range(len(root_ids)):
 
-                self.logger.debug("operation id: %d - root id: %d" %
-                                  (operation_id, root_ids[i_root_id]))
-                lock_acquired = self.lock_single_root(root_ids[i_root_id],
-                                                      operation_id)
+                self.logger.debug(
+                    "operation id: %d - root id: %d"
+                    % (operation_id, root_ids[i_root_id])
+                )
+                lock_acquired = self.lock_single_root(root_ids[i_root_id], operation_id)
 
                 # Roll back locks if one root cannot be locked
                 if not lock_acquired:
@@ -2540,9 +2903,8 @@ class ChunkedGraph(object):
 
         return False, root_ids
 
-    def lock_single_root(self, root_id: np.uint64, operation_id: np.uint64
-                         ) -> bool:
-        """ Attempts to lock the latest version of a root node
+    def lock_single_root(self, root_id: np.uint64, operation_id: np.uint64) -> bool:
+        """Attempts to lock the latest version of a root node
 
         :param root_id: uint64
         :param operation_id: uint64
@@ -2564,8 +2926,7 @@ class ChunkedGraph(object):
         time_cutoff = datetime.datetime.utcnow() - LOCK_EXPIRED_TIME_DELTA
 
         # Comply to resolution of BigTables TimeRange
-        time_cutoff -= datetime.timedelta(
-            microseconds=time_cutoff.microsecond % 1000)
+        time_cutoff -= datetime.timedelta(microseconds=time_cutoff.microsecond % 1000)
 
         time_filter = TimestampRangeFilter(TimestampRange(start=time_cutoff))
 
@@ -2577,35 +2938,43 @@ class ChunkedGraph(object):
             start_column=lock_column.key,
             end_column=lock_column.key,
             inclusive_start=True,
-            inclusive_end=True)
+            inclusive_end=True,
+        )
 
         new_parents_key_filter = ColumnRangeFilter(
             column_family_id=new_parents_column.family_id,
             start_column=new_parents_column.key,
             end_column=new_parents_column.key,
             inclusive_start=True,
-            inclusive_end=True)
+            inclusive_end=True,
+        )
 
         # Combine filters together
         chained_filter = RowFilterChain([time_filter, lock_key_filter])
         combined_filter = ConditionalRowFilter(
             base_filter=chained_filter,
             true_filter=PassAllFilter(True),
-            false_filter=new_parents_key_filter)
+            false_filter=new_parents_key_filter,
+        )
 
         # Get conditional row using the chained filter
-        root_row = self.table.row(serializers.serialize_uint64(root_id),
-                                  filter_=combined_filter)
+        root_row = self.table.row(
+            serializers.serialize_uint64(root_id), filter_=combined_filter
+        )
 
         # Set row lock if condition returns no results (state == False)
         time_stamp = datetime.datetime.utcnow()
 
         # Comply to resolution of BigTables TimeRange
-        time_stamp = get_google_compatible_time_stamp(time_stamp,
-                                                      round_up=False)
+        time_stamp = get_google_compatible_time_stamp(time_stamp, round_up=False)
 
-        root_row.set_cell(lock_column.family_id, lock_column.key, operation_id_b, state=False,
-                          timestamp=time_stamp)
+        root_row.set_cell(
+            lock_column.family_id,
+            lock_column.key,
+            operation_id_b,
+            state=False,
+            timestamp=time_stamp,
+        )
 
         # The lock was acquired when set_cell returns False (state)
         lock_acquired = not root_row.commit()
@@ -2619,7 +2988,7 @@ class ChunkedGraph(object):
         return lock_acquired
 
     def unlock_root(self, root_id: np.uint64, operation_id: np.uint64) -> bool:
-        """ Unlocks a root
+        """Unlocks a root
 
         This is mainly used for cases where multiple roots need to be locked and
         locking was not sucessful for all of them
@@ -2641,8 +3010,7 @@ class ChunkedGraph(object):
         time_cutoff = datetime.datetime.utcnow() - LOCK_EXPIRED_TIME_DELTA
 
         # Comply to resolution of BigTables TimeRange
-        time_cutoff -= datetime.timedelta(
-            microseconds=time_cutoff.microsecond % 1000)
+        time_cutoff -= datetime.timedelta(microseconds=time_cutoff.microsecond % 1000)
 
         time_filter = TimestampRangeFilter(TimestampRange(start=time_cutoff))
 
@@ -2654,30 +3022,33 @@ class ChunkedGraph(object):
             start_column=lock_column.key,
             end_column=lock_column.key,
             inclusive_start=True,
-            inclusive_end=True)
+            inclusive_end=True,
+        )
 
         value_filter = ValueRangeFilter(
             start_value=operation_id_b,
             end_value=operation_id_b,
             inclusive_start=True,
-            inclusive_end=True)
+            inclusive_end=True,
+        )
 
         # Chain these filters together
-        chained_filter = RowFilterChain([time_filter, column_key_filter,
-                                         value_filter])
+        chained_filter = RowFilterChain([time_filter, column_key_filter, value_filter])
 
         # Get conditional row using the chained filter
-        root_row = self.table.row(serializers.serialize_uint64(root_id),
-                                  filter_=chained_filter)
+        root_row = self.table.row(
+            serializers.serialize_uint64(root_id), filter_=chained_filter
+        )
 
         # Delete row if conditions are met (state == True)
         root_row.delete_cell(lock_column.family_id, lock_column.key, state=True)
 
         return root_row.commit()
 
-    def check_and_renew_root_locks(self, root_ids: Iterable[np.uint64],
-                                   operation_id: np.uint64) -> bool:
-        """ Tests if the roots are locked with the provided operation_id and
+    def check_and_renew_root_locks(
+        self, root_ids: Iterable[np.uint64], operation_id: np.uint64
+    ) -> bool:
+        """Tests if the roots are locked with the provided operation_id and
         renews the lock to reset the time_stam
 
         This is mainly used before executing a bulk write
@@ -2696,9 +3067,10 @@ class ChunkedGraph(object):
 
         return True
 
-    def check_and_renew_root_lock_single(self, root_id: np.uint64,
-                                         operation_id: np.uint64) -> bool:
-        """ Tests if the root is locked with the provided operation_id and
+    def check_and_renew_root_lock_single(
+        self, root_id: np.uint64, operation_id: np.uint64
+    ) -> bool:
+        """Tests if the root is locked with the provided operation_id and
         renews the lock to reset the time_stam
 
         This is mainly used before executing a bulk write
@@ -2728,44 +3100,51 @@ class ChunkedGraph(object):
             start_column=lock_column.key,
             end_column=lock_column.key,
             inclusive_start=True,
-            inclusive_end=True)
+            inclusive_end=True,
+        )
 
         value_filter = ValueRangeFilter(
             start_value=operation_id_b,
             end_value=operation_id_b,
             inclusive_start=True,
-            inclusive_end=True)
+            inclusive_end=True,
+        )
 
         new_parents_key_filter = ColumnRangeFilter(
             column_family_id=self.family_id,
             start_column=new_parents_column.key,
             end_column=new_parents_column.key,
             inclusive_start=True,
-            inclusive_end=True)
+            inclusive_end=True,
+        )
 
         # Chain these filters together
         chained_filter = RowFilterChain([column_key_filter, value_filter])
         combined_filter = ConditionalRowFilter(
             base_filter=chained_filter,
             true_filter=new_parents_key_filter,
-            false_filter=PassAllFilter(True))
+            false_filter=PassAllFilter(True),
+        )
 
         # Get conditional row using the chained filter
-        root_row = self.table.row(serializers.serialize_uint64(root_id),
-                                  filter_=combined_filter)
+        root_row = self.table.row(
+            serializers.serialize_uint64(root_id), filter_=combined_filter
+        )
 
         # Set row lock if condition returns a result (state == True)
-        root_row.set_cell(lock_column.family_id, lock_column.key, operation_id_b, state=False)
+        root_row.set_cell(
+            lock_column.family_id, lock_column.key, operation_id_b, state=False
+        )
 
         # The lock was acquired when set_cell returns True (state)
         lock_acquired = not root_row.commit()
 
         return lock_acquired
 
-    def read_consolidated_lock_timestamp(self, root_ids: Sequence[np.uint64],
-                                         operation_ids: Sequence[np.uint64]
-                                         ) -> Union[datetime.datetime, None]:
-        """ Returns minimum of many lock timestamps
+    def read_consolidated_lock_timestamp(
+        self, root_ids: Sequence[np.uint64], operation_ids: Sequence[np.uint64]
+    ) -> Union[datetime.datetime, None]:
+        """Returns minimum of many lock timestamps
 
         :param root_ids: np.ndarray
         :param operation_ids: np.ndarray
@@ -2785,9 +3164,10 @@ class ChunkedGraph(object):
 
         return np.min(time_stamps)
 
-    def read_lock_timestamp(self, root_id: np.uint64, operation_id: np.uint64
-                            ) -> Union[datetime.datetime, None]:
-        """ Reads timestamp from lock row to get a consistent timestamp across
+    def read_lock_timestamp(
+        self, root_id: np.uint64, operation_id: np.uint64
+    ) -> Union[datetime.datetime, None]:
+        """Reads timestamp from lock row to get a consistent timestamp across
             multiple nodes / pods
 
         :param root_id: np.uint64
@@ -2795,8 +3175,7 @@ class ChunkedGraph(object):
             Checks whether the root_id is actually locked with this operation_id
         :return: datetime.datetime or None
         """
-        row = self.read_node_id_row(root_id,
-                                    columns=column_keys.Concurrency.Lock)
+        row = self.read_node_id_row(root_id, columns=column_keys.Concurrency.Lock)
 
         if len(row) == 0:
             self.logger.warning(f"No lock found for {root_id}")
@@ -2809,7 +3188,7 @@ class ChunkedGraph(object):
         return row[0].timestamp
 
     def get_latest_root_id(self, root_id: np.uint64) -> np.ndarray:
-        """ Returns the latest root id associated with the provided root id
+        """Returns the latest root id associated with the provided root id
 
         :param root_id: uint64
         :return: list of uint64s
@@ -2821,7 +3200,7 @@ class ChunkedGraph(object):
 
         while len(id_working_set) > 0:
             next_id = id_working_set[0]
-            del(id_working_set[0])
+            del id_working_set[0]
             row = self.read_node_id_row(next_id, columns=column)
 
             # Check if a new root id was attached to this root id
@@ -2832,10 +3211,12 @@ class ChunkedGraph(object):
 
         return np.unique(latest_root_ids)
 
-    def get_future_root_ids(self, root_id: np.uint64,
-                            time_stamp: Optional[datetime.datetime] =
-                            get_max_time())-> np.ndarray:
-        """ Returns all future root ids emerging from this root
+    def get_future_root_ids(
+        self,
+        root_id: np.uint64,
+        time_stamp: Optional[datetime.datetime] = get_max_time(),
+    ) -> np.ndarray:
+        """Returns all future root ids emerging from this root
 
         This search happens in a monotic fashion. At no point are past root
         ids of future root ids taken into account.
@@ -2850,8 +3231,7 @@ class ChunkedGraph(object):
             time_stamp = UTC.localize(time_stamp)
 
         # Comply to resolution of BigTables TimeRange
-        time_stamp = get_google_compatible_time_stamp(time_stamp,
-                                                      round_up=False)
+        time_stamp = get_google_compatible_time_stamp(time_stamp, round_up=False)
 
         id_history = []
 
@@ -2860,8 +3240,13 @@ class ChunkedGraph(object):
             temp_next_ids = []
 
             for next_id in next_ids:
-                row = self.read_node_id_row(next_id, columns=[column_keys.Hierarchy.NewParent,
-                                                              column_keys.Hierarchy.Child])
+                row = self.read_node_id_row(
+                    next_id,
+                    columns=[
+                        column_keys.Hierarchy.NewParent,
+                        column_keys.Hierarchy.Child,
+                    ],
+                )
                 if column_keys.Hierarchy.NewParent in row:
                     ids = row[column_keys.Hierarchy.NewParent][0].value
                     row_time_stamp = row[column_keys.Hierarchy.NewParent][0].timestamp
@@ -2869,7 +3254,9 @@ class ChunkedGraph(object):
                     ids = None
                     row_time_stamp = row[column_keys.Hierarchy.Child][0].timestamp
                 else:
-                    raise cg_exceptions.ChunkedGraphError("Error retrieving future root ID of %s" % next_id)
+                    raise cg_exceptions.ChunkedGraphError(
+                        "Error retrieving future root ID of %s" % next_id
+                    )
 
                 if row_time_stamp < time_stamp:
                     if ids is not None:
@@ -2882,10 +3269,12 @@ class ChunkedGraph(object):
 
         return np.unique(np.array(id_history, dtype=np.uint64))
 
-    def get_past_root_ids(self, root_id: np.uint64,
-                          time_stamp: Optional[datetime.datetime] =
-                          get_min_time()) -> np.ndarray:
-        """ Returns all future root ids emerging from this root
+    def get_past_root_ids(
+        self,
+        root_id: np.uint64,
+        time_stamp: Optional[datetime.datetime] = get_min_time(),
+    ) -> np.ndarray:
+        """Returns all future root ids emerging from this root
 
         This search happens in a monotic fashion. At no point are future root
         ids of past root ids taken into account.
@@ -2900,8 +3289,7 @@ class ChunkedGraph(object):
             time_stamp = UTC.localize(time_stamp)
 
         # Comply to resolution of BigTables TimeRange
-        time_stamp = get_google_compatible_time_stamp(time_stamp,
-                                                      round_up=False)
+        time_stamp = get_google_compatible_time_stamp(time_stamp, round_up=False)
 
         id_history = []
 
@@ -2910,16 +3298,25 @@ class ChunkedGraph(object):
             temp_next_ids = []
 
             for next_id in next_ids:
-                row = self.read_node_id_row(next_id, columns=[column_keys.Hierarchy.FormerParent,
-                                                              column_keys.Hierarchy.Child])
+                row = self.read_node_id_row(
+                    next_id,
+                    columns=[
+                        column_keys.Hierarchy.FormerParent,
+                        column_keys.Hierarchy.Child,
+                    ],
+                )
                 if column_keys.Hierarchy.FormerParent in row:
                     ids = row[column_keys.Hierarchy.FormerParent][0].value
-                    row_time_stamp = row[column_keys.Hierarchy.FormerParent][0].timestamp
+                    row_time_stamp = row[column_keys.Hierarchy.FormerParent][
+                        0
+                    ].timestamp
                 elif column_keys.Hierarchy.Child in row:
                     ids = None
                     row_time_stamp = row[column_keys.Hierarchy.Child][0].timestamp
                 else:
-                    raise cg_exceptions.ChunkedGraphError("Error retrieving past root ID of %s" % next_id)
+                    raise cg_exceptions.ChunkedGraphError(
+                        "Error retrieving past root ID of %s" % next_id
+                    )
 
                 if row_time_stamp > time_stamp:
                     if ids is not None:
@@ -2932,13 +3329,13 @@ class ChunkedGraph(object):
 
         return np.unique(np.array(id_history, dtype=np.uint64))
 
-    def get_root_id_history(self, root_id: np.uint64,
-                            time_stamp_past:
-                            Optional[datetime.datetime] = get_min_time(),
-                            time_stamp_future:
-                            Optional[datetime.datetime] = get_max_time()
-                            ) -> np.ndarray:
-        """ Returns all future root ids emerging from this root
+    def get_root_id_history(
+        self,
+        root_id: np.uint64,
+        time_stamp_past: Optional[datetime.datetime] = get_min_time(),
+        time_stamp_future: Optional[datetime.datetime] = get_max_time(),
+    ) -> np.ndarray:
+        """Returns all future root ids emerging from this root
 
         This search happens in a monotic fashion. At no point are future root
         ids of past root ids or past root ids of future root ids taken into
@@ -2953,22 +3350,24 @@ class ChunkedGraph(object):
             None=search whole future
         :return: array of uint64
         """
-        past_ids = self.get_past_root_ids(root_id=root_id,
-                                          time_stamp=time_stamp_past)
-        future_ids = self.get_future_root_ids(root_id=root_id,
-                                              time_stamp=time_stamp_future)
+        past_ids = self.get_past_root_ids(root_id=root_id, time_stamp=time_stamp_past)
+        future_ids = self.get_future_root_ids(
+            root_id=root_id, time_stamp=time_stamp_future
+        )
 
-        history_ids = np.concatenate([past_ids,
-                                      np.array([root_id], dtype=np.uint64),
-                                      future_ids])
+        history_ids = np.concatenate(
+            [past_ids, np.array([root_id], dtype=np.uint64), future_ids]
+        )
 
         return history_ids
 
-    def get_change_log(self, root_id: np.uint64,
-                       correct_for_wrong_coord_type: bool = True,
-                       time_stamp_past: Optional[datetime.datetime] = get_min_time()
-                       ) -> dict:
-        """ Returns all past root ids for this root
+    def get_change_log(
+        self,
+        root_id: np.uint64,
+        correct_for_wrong_coord_type: bool = True,
+        time_stamp_past: Optional[datetime.datetime] = get_min_time(),
+    ) -> dict:
+        """Returns all past root ids for this root
 
         This search happens in a monotic fashion. At no point are future root
         ids of past root ids taken into account.
@@ -2997,8 +3396,9 @@ class ChunkedGraph(object):
         while len(next_ids):
             temp_next_ids = []
             former_parent_col = column_keys.Hierarchy.FormerParent
-            row_dict = self.read_node_id_rows(node_ids=next_ids,
-                                              columns=[former_parent_col])
+            row_dict = self.read_node_id_rows(
+                node_ids=next_ids, columns=[former_parent_col]
+            )
 
             for row in row_dict.values():
                 if column_keys.Hierarchy.FormerParent in row:
@@ -3008,8 +3408,7 @@ class ChunkedGraph(object):
                     ids = row[former_parent_col][0].value
 
                     lock_col = column_keys.Concurrency.Lock
-                    former_row = self.read_node_id_row(ids[0],
-                                                       columns=[lock_col])
+                    former_row = self.read_node_id_row(ids[0], columns=[lock_col])
                     operation_id = former_row[lock_col][0].value
                     log_row = self.read_log_row(operation_id)
                     is_merge = column_keys.OperationLogs.AddedEdge in log_row
@@ -3027,13 +3426,17 @@ class ChunkedGraph(object):
                         added_edges = log_row[column_keys.OperationLogs.AddedEdge]
                         merge_history.append(added_edges)
 
-                        coords = [log_row[column_keys.OperationLogs.SourceCoordinate],
-                                  log_row[column_keys.OperationLogs.SinkCoordinate]]
+                        coords = [
+                            log_row[column_keys.OperationLogs.SourceCoordinate],
+                            log_row[column_keys.OperationLogs.SinkCoordinate],
+                        ]
 
                         if correct_for_wrong_coord_type:
                             # A little hack because we got the datatype wrong...
-                            coords = [np.frombuffer(coords[0]),
-                                      np.frombuffer(coords[1])]
+                            coords = [
+                                np.frombuffer(coords[0]),
+                                np.frombuffer(coords[1]),
+                            ]
                             coords *= self.segmentation_resolution
 
                         merge_history_edges.append(coords)
@@ -3053,54 +3456,74 @@ class ChunkedGraph(object):
             n_splits += user_dict[user_id]["n_splits"]
             n_mergers += user_dict[user_id]["n_mergers"]
 
-        return {"n_splits": n_splits,
-                "n_mergers": n_mergers,
-                "user_info": user_dict,
-                "past_ids": np.unique(np.array(id_history, dtype=np.uint64)),
-                "merge_edges": np.array(merge_history),
-                "merge_edge_coords": np.array(merge_history_edges),
-                "split_edges": np.array(split_history)}
+        return {
+            "n_splits": n_splits,
+            "n_mergers": n_mergers,
+            "user_info": user_dict,
+            "past_ids": np.unique(np.array(id_history, dtype=np.uint64)),
+            "merge_edges": np.array(merge_history),
+            "merge_edge_coords": np.array(merge_history_edges),
+            "split_edges": np.array(split_history),
+        }
 
-    def normalize_bounding_box(self,
-                               bounding_box: Optional[Sequence[Sequence[int]]],
-                               bb_is_coordinate: bool) -> \
-            Union[Sequence[Sequence[int]], None]:
+    def normalize_bounding_box(
+        self, bounding_box: Optional[Sequence[Sequence[int]]], bb_is_coordinate: bool
+    ) -> Union[Sequence[Sequence[int]], None]:
         if bounding_box is None:
             return None
 
         if bb_is_coordinate:
             bounding_box[0] = self.get_chunk_coordinates_from_vol_coordinates(
-                bounding_box[0][0], bounding_box[0][1], bounding_box[0][2],
-                resolution=self.cv.resolution, ceil=False)
+                bounding_box[0][0],
+                bounding_box[0][1],
+                bounding_box[0][2],
+                resolution=self.cv.resolution,
+                ceil=False,
+            )
             bounding_box[1] = self.get_chunk_coordinates_from_vol_coordinates(
-                bounding_box[1][0], bounding_box[1][1], bounding_box[1][2],
-                resolution=self.cv.resolution, ceil=True)
+                bounding_box[1][0],
+                bounding_box[1][1],
+                bounding_box[1][2],
+                resolution=self.cv.resolution,
+                ceil=True,
+            )
             return bounding_box
         else:
             return np.array(bounding_box, dtype=np.int)
 
     def _get_subgraph_higher_layer_nodes(
-            self, node_id: np.uint64,
-            bounding_box: Optional[Sequence[Sequence[int]]],
-            return_layers: Sequence[int],
-            verbose: bool):
-
+        self,
+        node_id: np.uint64,
+        bounding_box: Optional[Sequence[Sequence[int]]],
+        return_layers: Sequence[int],
+        verbose: bool,
+    ):
         def _get_subgraph_higher_layer_nodes_threaded(
-                node_ids: Iterable[np.uint64]) -> List[np.uint64]:
+            node_ids: Iterable[np.uint64],
+        ) -> List[np.uint64]:
             children = self.get_children(node_ids, flatten=True)
 
             if len(children) > 0 and bounding_box is not None:
-                chunk_coordinates = np.array([self.get_chunk_coordinates(c) for c in children])
+                chunk_coordinates = np.array(
+                    [self.get_chunk_coordinates(c) for c in children]
+                )
                 child_layers = self.get_chunk_layers(children)
                 adapt_child_layers = child_layers - 2
                 adapt_child_layers[adapt_child_layers < 0] = 0
 
-                bounding_box_layer = bounding_box[None] / \
-                                     (self.fan_out ** adapt_child_layers)[:, None, None]
+                bounding_box_layer = (
+                    bounding_box[None]
+                    / (self.fan_out ** adapt_child_layers)[:, None, None]
+                )
 
-                bound_check = np.array([
-                    np.all(chunk_coordinates < bounding_box_layer[:, 1], axis=1),
-                    np.all(chunk_coordinates + 1 > bounding_box_layer[:, 0], axis=1)]).T
+                bound_check = np.array(
+                    [
+                        np.all(chunk_coordinates < bounding_box_layer[:, 1], axis=1),
+                        np.all(
+                            chunk_coordinates + 1 > bounding_box_layer[:, 0], axis=1
+                        ),
+                    ]
+                ).T
 
                 bound_check_mask = np.all(bound_check, axis=1)
                 children = children[bound_check_mask]
@@ -3133,16 +3556,29 @@ class ChunkedGraph(object):
             n_child_ids = len(child_ids)
             this_n_threads = np.min([int(n_child_ids // 50000) + 1, mu.n_cpus])
 
-            child_ids = np.fromiter(chain.from_iterable(mu.multithread_func(
-                _get_subgraph_higher_layer_nodes_threaded,
-                np.array_split(this_layer_child_ids, this_n_threads),
-                n_threads=this_n_threads, debug=this_n_threads == 1)), np.uint64)
+            child_ids = np.fromiter(
+                chain.from_iterable(
+                    mu.multithread_func(
+                        _get_subgraph_higher_layer_nodes_threaded,
+                        np.array_split(this_layer_child_ids, this_n_threads),
+                        n_threads=this_n_threads,
+                        debug=this_n_threads == 1,
+                    )
+                ),
+                np.uint64,
+            )
             child_ids = np.concatenate([child_ids, next_layer_child_ids])
 
             if verbose:
-                self.logger.debug("Layer %d: %.3fms for %d children with %d threads" %
-                                  (layer, (time.time() - time_start) * 1000, n_child_ids,
-                                   this_n_threads))
+                self.logger.debug(
+                    "Layer %d: %.3fms for %d children with %d threads"
+                    % (
+                        layer,
+                        (time.time() - time_start) * 1000,
+                        n_child_ids,
+                        this_n_threads,
+                    )
+                )
                 time_start = time.time()
 
             layer -= 1
@@ -3151,13 +3587,15 @@ class ChunkedGraph(object):
 
         return nodes_per_layer
 
-    def get_subgraph_edges(self, agglomeration_id: np.uint64,
-                           bounding_box: Optional[Sequence[Sequence[int]]] = None,
-                           bb_is_coordinate: bool = False,
-                           connected_edges=True,
-                           verbose: bool = True
-                           ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """ Return all atomic edges between supervoxels belonging to the
+    def get_subgraph_edges(
+        self,
+        agglomeration_id: np.uint64,
+        bounding_box: Optional[Sequence[Sequence[int]]] = None,
+        bb_is_coordinate: bool = False,
+        connected_edges=True,
+        verbose: bool = True,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Return all atomic edges between supervoxels belonging to the
             specified agglomeration ID within the defined bounding box
 
         :param agglomeration_id: int
@@ -3167,26 +3605,30 @@ class ChunkedGraph(object):
         :return: edge list
         """
 
-        def _get_subgraph_layer2_edges(node_ids) -> \
-                Tuple[List[np.ndarray], List[np.float32], List[np.uint64]]:
-            return self.get_subgraph_chunk(node_ids,
-                                           connected_edges=connected_edges,
-                                           time_stamp=time_stamp)
+        def _get_subgraph_layer2_edges(
+            node_ids,
+        ) -> Tuple[List[np.ndarray], List[np.float32], List[np.uint64]]:
+            return self.get_subgraph_chunk(
+                node_ids, connected_edges=connected_edges, time_stamp=time_stamp
+            )
 
-        time_stamp = self.read_node_id_row(agglomeration_id,
-                                           columns=column_keys.Hierarchy.Child)[0].timestamp
+        time_stamp = self.read_node_id_row(
+            agglomeration_id, columns=column_keys.Hierarchy.Child
+        )[0].timestamp
 
         bounding_box = self.normalize_bounding_box(bounding_box, bb_is_coordinate)
 
         # Layer 3+
         child_ids = self._get_subgraph_higher_layer_nodes(
-            node_id=agglomeration_id, bounding_box=bounding_box,
-            return_layers=[2], verbose=verbose)[2]
+            node_id=agglomeration_id,
+            bounding_box=bounding_box,
+            return_layers=[2],
+            verbose=verbose,
+        )[2]
 
         # Layer 2
         if verbose:
             time_start = time.time()
-
 
         child_chunk_ids = self.get_chunk_ids_from_node_ids(child_ids)
         u_ccids = np.unique(child_chunk_ids)
@@ -3202,7 +3644,9 @@ class ChunkedGraph(object):
         edge_infos = mu.multithread_func(
             _get_subgraph_layer2_edges,
             np.array_split(child_ids, this_n_threads),
-            n_threads=this_n_threads, debug=this_n_threads == 1)
+            n_threads=this_n_threads,
+            debug=this_n_threads == 1,
+        )
 
         affinities = np.array([], dtype=np.float32)
         areas = np.array([], dtype=np.uint64)
@@ -3215,19 +3659,22 @@ class ChunkedGraph(object):
             edges = np.concatenate([edges, _edges])
 
         if verbose:
-            self.logger.debug("Layer %d: %.3fms for %d childs with %d threads" %
-                              (2, (time.time() - time_start) * 1000,
-                               n_child_ids, this_n_threads))
+            self.logger.debug(
+                "Layer %d: %.3fms for %d childs with %d threads"
+                % (2, (time.time() - time_start) * 1000, n_child_ids, this_n_threads)
+            )
 
         return edges, affinities, areas
 
-    def get_subgraph_nodes(self, agglomeration_id: np.uint64,
-                           bounding_box: Optional[Sequence[Sequence[int]]] = None,
-                           bb_is_coordinate: bool = False,
-                           return_layers: List[int] = [1],
-                           verbose: bool = True) -> \
-            Union[Dict[int, np.ndarray], np.ndarray]:
-        """ Return all nodes belonging to the specified agglomeration ID within
+    def get_subgraph_nodes(
+        self,
+        agglomeration_id: np.uint64,
+        bounding_box: Optional[Sequence[Sequence[int]]] = None,
+        bb_is_coordinate: bool = False,
+        return_layers: List[int] = [1],
+        verbose: bool = True,
+    ) -> Union[Dict[int, np.ndarray], np.ndarray]:
+        """Return all nodes belonging to the specified agglomeration ID within
             the defined bounding box and requested layers.
 
         :param agglomeration_id: np.uint64
@@ -3243,19 +3690,24 @@ class ChunkedGraph(object):
             return self.get_children(node_ids, flatten=True)
 
         stop_layer = np.min(return_layers)
-        bounding_box = self.normalize_bounding_box(bounding_box,
-                                                   bb_is_coordinate)
+        bounding_box = self.normalize_bounding_box(bounding_box, bb_is_coordinate)
 
         # Layer 3+
         if stop_layer >= 2:
             nodes_per_layer = self._get_subgraph_higher_layer_nodes(
-                node_id=agglomeration_id, bounding_box=bounding_box,
-                return_layers=return_layers, verbose=verbose)
+                node_id=agglomeration_id,
+                bounding_box=bounding_box,
+                return_layers=return_layers,
+                verbose=verbose,
+            )
         else:
             # Need to retrieve layer 2 even if the user doesn't require it
             nodes_per_layer = self._get_subgraph_higher_layer_nodes(
-                node_id=agglomeration_id, bounding_box=bounding_box,
-                return_layers=return_layers+[2], verbose=verbose)
+                node_id=agglomeration_id,
+                bounding_box=bounding_box,
+                return_layers=return_layers + [2],
+                verbose=verbose,
+            )
 
             # Layer 2
             if verbose:
@@ -3269,15 +3721,23 @@ class ChunkedGraph(object):
             n_child_ids = len(child_ids)
             this_n_threads = np.min([int(n_child_ids // 50000) + 1, mu.n_cpus])
 
-            child_ids = np.fromiter(chain.from_iterable(mu.multithread_func(
-                _get_subgraph_layer2_nodes,
-                np.array_split(child_ids, this_n_threads),
-                n_threads=this_n_threads, debug=this_n_threads == 1)), dtype=np.uint64)
+            child_ids = np.fromiter(
+                chain.from_iterable(
+                    mu.multithread_func(
+                        _get_subgraph_layer2_nodes,
+                        np.array_split(child_ids, this_n_threads),
+                        n_threads=this_n_threads,
+                        debug=this_n_threads == 1,
+                    )
+                ),
+                dtype=np.uint64,
+            )
 
             if verbose:
-                self.logger.debug("Layer 2: %.3fms for %d children with %d threads" %
-                                  ((time.time() - time_start) * 1000, n_child_ids,
-                                   this_n_threads))
+                self.logger.debug(
+                    "Layer 2: %.3fms for %d children with %d threads"
+                    % ((time.time() - time_start) * 1000, n_child_ids, this_n_threads)
+                )
 
             nodes_per_layer[1] = child_ids
 
@@ -3286,9 +3746,10 @@ class ChunkedGraph(object):
         else:
             return nodes_per_layer
 
-    def flatten_row_dict(self, row_dict: Dict[column_keys._Column,
-                                              List[bigtable.row_data.Cell]]) -> Dict:
-        """ Flattens multiple entries to columns by appending them
+    def flatten_row_dict(
+        self, row_dict: Dict[column_keys._Column, List[bigtable.row_data.Cell]]
+    ) -> Dict:
+        """Flattens multiple entries to columns by appending them
 
         :param row_dict: dict
             family key has to be resolved
@@ -3306,19 +3767,22 @@ class ChunkedGraph(object):
                 if np.isscalar(column_entry.value):
                     flattened_row_dict[column] = np.array(flattened_row_dict[column])
                 else:
-                    flattened_row_dict[column] = np.concatenate(flattened_row_dict[column])
+                    flattened_row_dict[column] = np.concatenate(
+                        flattened_row_dict[column]
+                    )
             else:
-                flattened_row_dict[column] = column.deserialize(b'')
+                flattened_row_dict[column] = column.deserialize(b"")
 
             if column == column_keys.Connectivity.Connected:
-                u_ids, c_ids = np.unique(flattened_row_dict[column],
-                                         return_counts=True)
-                flattened_row_dict[column] = u_ids[(c_ids % 2) == 1].astype(column.basetype)
+                u_ids, c_ids = np.unique(flattened_row_dict[column], return_counts=True)
+                flattened_row_dict[column] = u_ids[(c_ids % 2) == 1].astype(
+                    column.basetype
+                )
 
         return flattened_row_dict
 
     def get_chunk_split_partners(self, atomic_id: np.uint64):
-        """ Finds all atomic nodes beloning to the same supervoxel before
+        """Finds all atomic nodes beloning to the same supervoxel before
             chunking (affs == inf)
 
         :param atomic_id: np.uint64
@@ -3332,21 +3796,25 @@ class ChunkedGraph(object):
             atomic_id = atomic_ids[0]
             del atomic_ids[0]
 
-            partners, affs, _ = self.get_atomic_partners(atomic_id,
-                                                         include_connected_partners=True,
-                                                         include_disconnected_partners=False)
+            partners, affs, _ = self.get_atomic_partners(
+                atomic_id,
+                include_connected_partners=True,
+                include_disconnected_partners=False,
+            )
 
             m = np.isinf(affs)
 
             inf_partners = partners[m]
-            new_chunk_split_partners = inf_partners[~np.in1d(inf_partners, chunk_split_partners)]
+            new_chunk_split_partners = inf_partners[
+                ~np.in1d(inf_partners, chunk_split_partners)
+            ]
             atomic_ids.extend(new_chunk_split_partners)
             chunk_split_partners.extend(new_chunk_split_partners)
 
         return chunk_split_partners
 
     def get_all_original_partners(self, atomic_id: np.uint64):
-        """ Finds all partners from the unchunked region graph
+        """Finds all partners from the unchunked region graph
             Merges split supervoxels over chunk boundaries first (affs == inf)
 
         :param atomic_id: np.uint64
@@ -3360,24 +3828,27 @@ class ChunkedGraph(object):
             atomic_id = atomic_ids[0]
             del atomic_ids[0]
 
-            partners, affs, _ = self.get_atomic_partners(atomic_id,
-                                                         include_connected_partners=True,
-                                                         include_disconnected_partners=False)
+            partners, affs, _ = self.get_atomic_partners(
+                atomic_id,
+                include_connected_partners=True,
+                include_disconnected_partners=False,
+            )
 
             m = np.isinf(affs)
             partner_dict[atomic_id] = partners[~m]
 
             inf_partners = partners[m]
             new_chunk_split_partners = inf_partners[
-                ~np.in1d(inf_partners, list(partner_dict.keys()))]
+                ~np.in1d(inf_partners, list(partner_dict.keys()))
+            ]
             atomic_ids.extend(new_chunk_split_partners)
 
         return partner_dict
 
-    def get_atomic_node_partners(self, atomic_id: np.uint64,
-                                 time_stamp: datetime.datetime = get_max_time()
-                                 ) -> Dict:
-        """ Reads register partner ids
+    def get_atomic_node_partners(
+        self, atomic_id: np.uint64, time_stamp: datetime.datetime = get_max_time()
+    ) -> Dict:
+        """Reads register partner ids
 
         :param atomic_id: np.uint64
         :param time_stamp: datetime.datetime
@@ -3386,49 +3857,62 @@ class ChunkedGraph(object):
         col_partner = column_keys.Connectivity.Partner
         col_connected = column_keys.Connectivity.Connected
         columns = [col_partner, col_connected]
-        row_dict = self.read_node_id_row(atomic_id, columns=columns,
-                                         end_time=time_stamp, end_time_inclusive=True)
+        row_dict = self.read_node_id_row(
+            atomic_id, columns=columns, end_time=time_stamp, end_time_inclusive=True
+        )
         flattened_row_dict = self.flatten_row_dict(row_dict)
         return flattened_row_dict[col_partner][flattened_row_dict[col_connected]]
 
     def _get_atomic_node_info_core(self, row_dict) -> Dict:
-        """ Reads connectivity information for a single node
+        """Reads connectivity information for a single node
 
         :param atomic_id: np.uint64
         :param time_stamp: datetime.datetime
         :return: dict
         """
         flattened_row_dict = self.flatten_row_dict(row_dict)
-        all_ids = np.arange(len(flattened_row_dict[column_keys.Connectivity.Partner]),
-                            dtype=column_keys.Connectivity.Partner.basetype)
-        disconnected_m = ~np.in1d(all_ids,
-                                  flattened_row_dict[column_keys.Connectivity.Connected])
-        flattened_row_dict[column_keys.Connectivity.Disconnected] = all_ids[disconnected_m]
+        all_ids = np.arange(
+            len(flattened_row_dict[column_keys.Connectivity.Partner]),
+            dtype=column_keys.Connectivity.Partner.basetype,
+        )
+        disconnected_m = ~np.in1d(
+            all_ids, flattened_row_dict[column_keys.Connectivity.Connected]
+        )
+        flattened_row_dict[column_keys.Connectivity.Disconnected] = all_ids[
+            disconnected_m
+        ]
 
         return flattened_row_dict
 
-    def get_atomic_node_info(self, atomic_id: np.uint64,
-                             time_stamp: datetime.datetime = get_max_time()
-                             ) -> Dict:
-        """ Reads connectivity information for a single node
+    def get_atomic_node_info(
+        self, atomic_id: np.uint64, time_stamp: datetime.datetime = get_max_time()
+    ) -> Dict:
+        """Reads connectivity information for a single node
 
         :param atomic_id: np.uint64
         :param time_stamp: datetime.datetime
         :return: dict
         """
-        columns = [column_keys.Connectivity.Connected, column_keys.Connectivity.Affinity,
-                   column_keys.Connectivity.Area, column_keys.Connectivity.Partner,
-                   column_keys.Hierarchy.Parent]
-        row_dict = self.read_node_id_row(atomic_id, columns=columns,
-                                         end_time=time_stamp, end_time_inclusive=True)
+        columns = [
+            column_keys.Connectivity.Connected,
+            column_keys.Connectivity.Affinity,
+            column_keys.Connectivity.Area,
+            column_keys.Connectivity.Partner,
+            column_keys.Hierarchy.Parent,
+        ]
+        row_dict = self.read_node_id_row(
+            atomic_id, columns=columns, end_time=time_stamp, end_time_inclusive=True
+        )
 
         return self._get_atomic_node_info_core(row_dict)
 
-    def _get_atomic_partners_core(self, flattened_row_dict: Dict,
-                                  include_connected_partners=True,
-                                  include_disconnected_partners=False
-                                  ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """ Extracts the atomic partners and affinities for a given timestamp
+    def _get_atomic_partners_core(
+        self,
+        flattened_row_dict: Dict,
+        include_connected_partners=True,
+        include_disconnected_partners=False,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Extracts the atomic partners and affinities for a given timestamp
 
         :param flattened_row_dict: dict
         :param include_connected_partners: bool
@@ -3445,7 +3929,9 @@ class ChunkedGraph(object):
         for column in columns:
             included_ids.extend(flattened_row_dict[column])
 
-        included_ids = np.array(included_ids, dtype=column_keys.Connectivity.Connected.basetype)
+        included_ids = np.array(
+            included_ids, dtype=column_keys.Connectivity.Connected.basetype
+        )
 
         areas = flattened_row_dict[column_keys.Connectivity.Area][included_ids]
         affinities = flattened_row_dict[column_keys.Connectivity.Affinity][included_ids]
@@ -3453,12 +3939,14 @@ class ChunkedGraph(object):
 
         return partners, affinities, areas
 
-    def get_atomic_partners(self, atomic_id: np.uint64,
-                            include_connected_partners=True,
-                            include_disconnected_partners=False,
-                            time_stamp: Optional[datetime.datetime] = get_max_time()
-                            ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """ Extracts the atomic partners and affinities for a given timestamp
+    def get_atomic_partners(
+        self,
+        atomic_id: np.uint64,
+        include_connected_partners=True,
+        include_disconnected_partners=False,
+        time_stamp: Optional[datetime.datetime] = get_max_time(),
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Extracts the atomic partners and affinities for a given timestamp
 
         :param atomic_id: np.uint64
         :param include_connected_partners: bool
@@ -3468,48 +3956,67 @@ class ChunkedGraph(object):
         """
         assert include_connected_partners or include_disconnected_partners
 
-        flattened_row_dict = self.get_atomic_node_info(atomic_id,
-                                                       time_stamp=time_stamp)
+        flattened_row_dict = self.get_atomic_node_info(atomic_id, time_stamp=time_stamp)
 
-        return self._get_atomic_partners_core(flattened_row_dict,
-                                              include_connected_partners,
-                                              include_disconnected_partners)
+        return self._get_atomic_partners_core(
+            flattened_row_dict,
+            include_connected_partners,
+            include_disconnected_partners,
+        )
 
-    def _retrieve_connectivity(self, dict_item: Tuple[np.uint64, Dict[column_keys._Column, List[bigtable.row_data.Cell]]],
-                               connected_edges: bool = True):
+    def _retrieve_connectivity(
+        self,
+        dict_item: Tuple[
+            np.uint64, Dict[column_keys._Column, List[bigtable.row_data.Cell]]
+        ],
+        connected_edges: bool = True,
+    ):
         node_id, row = dict_item
 
         tmp = set()
-        for x in itertools.chain.from_iterable(generation.value for generation in row[column_keys.Connectivity.Connected][::-1]):
+        for x in itertools.chain.from_iterable(
+            generation.value
+            for generation in row[column_keys.Connectivity.Connected][::-1]
+        ):
             tmp.remove(x) if x in tmp else tmp.add(x)
 
         connected_indices = np.fromiter(tmp, np.uint64)
         if column_keys.Connectivity.Partner in row:
-            edges = np.fromiter(itertools.chain.from_iterable(
-                (node_id, partner_id)
-                for generation in row[column_keys.Connectivity.Partner][::-1]
-                for partner_id in generation.value),
-                dtype=basetypes.NODE_ID).reshape((-1, 2))
-            edges = self._connected_or_not(edges, connected_indices,
-                                           connected_edges)
+            edges = np.fromiter(
+                itertools.chain.from_iterable(
+                    (node_id, partner_id)
+                    for generation in row[column_keys.Connectivity.Partner][::-1]
+                    for partner_id in generation.value
+                ),
+                dtype=basetypes.NODE_ID,
+            ).reshape((-1, 2))
+            edges = self._connected_or_not(edges, connected_indices, connected_edges)
         else:
             edges = np.empty((0, 2), basetypes.NODE_ID)
 
         if column_keys.Connectivity.Affinity in row:
-            affinities = np.fromiter(itertools.chain.from_iterable(
-                generation.value for generation in row[column_keys.Connectivity.Affinity][::-1]),
-                dtype=basetypes.EDGE_AFFINITY)
-            affinities = self._connected_or_not(affinities, connected_indices,
-                                                connected_edges)
+            affinities = np.fromiter(
+                itertools.chain.from_iterable(
+                    generation.value
+                    for generation in row[column_keys.Connectivity.Affinity][::-1]
+                ),
+                dtype=basetypes.EDGE_AFFINITY,
+            )
+            affinities = self._connected_or_not(
+                affinities, connected_indices, connected_edges
+            )
         else:
             affinities = np.empty(0, basetypes.EDGE_AFFINITY)
 
         if column_keys.Connectivity.Area in row:
-            areas = np.fromiter(itertools.chain.from_iterable(
-                generation.value for generation in row[column_keys.Connectivity.Area][::-1]),
-                dtype=basetypes.EDGE_AREA)
-            areas = self._connected_or_not(areas, connected_indices,
-                                           connected_edges)
+            areas = np.fromiter(
+                itertools.chain.from_iterable(
+                    generation.value
+                    for generation in row[column_keys.Connectivity.Area][::-1]
+                ),
+                dtype=basetypes.EDGE_AREA,
+            )
+            areas = self._connected_or_not(areas, connected_indices, connected_edges)
         else:
             areas = np.empty(0, basetypes.EDGE_AREA)
 
@@ -3529,11 +4036,13 @@ class ChunkedGraph(object):
         else:
             return array[~mask, ...]
 
-    def get_subgraph_chunk(self, node_ids: Iterable[np.uint64],
-                           make_unique: bool = True,
-                           connected_edges: bool = True,
-                           time_stamp: Optional[datetime.datetime] = None
-                           ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def get_subgraph_chunk(
+        self,
+        node_ids: Iterable[np.uint64],
+        make_unique: bool = True,
+        connected_edges: bool = True,
+        time_stamp: Optional[datetime.datetime] = None,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
         Takes a list of lvl2 ids and returns the edges, affinities, and areas
         of their children (their associated supervoxels).
@@ -3552,37 +4061,50 @@ class ChunkedGraph(object):
 
         child_ids = self.get_children(node_ids, flatten=True)
 
-        row_dict = self.read_node_id_rows(node_ids=child_ids,
-                                          columns=[column_keys.Connectivity.Area,
-                                                   column_keys.Connectivity.Affinity,
-                                                   column_keys.Connectivity.Partner,
-                                                   column_keys.Connectivity.Connected,
-                                                   column_keys.Connectivity.Disconnected],
-                                          end_time=time_stamp,
-                                          end_time_inclusive=True)
+        row_dict = self.read_node_id_rows(
+            node_ids=child_ids,
+            columns=[
+                column_keys.Connectivity.Area,
+                column_keys.Connectivity.Affinity,
+                column_keys.Connectivity.Partner,
+                column_keys.Connectivity.Connected,
+                column_keys.Connectivity.Disconnected,
+            ],
+            end_time=time_stamp,
+            end_time_inclusive=True,
+        )
 
         tmp_edges, tmp_affinites, tmp_areas = [], [], []
         for row_dict_item in row_dict.items():
-            edges, affinities, areas = self._retrieve_connectivity(row_dict_item,
-                                                                   connected_edges)
+            edges, affinities, areas = self._retrieve_connectivity(
+                row_dict_item, connected_edges
+            )
             tmp_edges.append(edges)
             tmp_affinites.append(affinities)
             tmp_areas.append(areas)
 
-        edges = np.concatenate(tmp_edges) if tmp_edges \
+        edges = (
+            np.concatenate(tmp_edges)
+            if tmp_edges
             else np.empty((0, 2), dtype=basetypes.NODE_ID)
-        affinities = np.concatenate(tmp_affinites) if tmp_affinites \
+        )
+        affinities = (
+            np.concatenate(tmp_affinites)
+            if tmp_affinites
             else np.empty(0, dtype=basetypes.EDGE_AFFINITY)
-        areas = np.concatenate(tmp_areas) if tmp_areas \
+        )
+        areas = (
+            np.concatenate(tmp_areas)
+            if tmp_areas
             else np.empty(0, dtype=basetypes.EDGE_AREA)
+        )
 
         # If requested, remove duplicate edges. Every edge is stored in each
         # participating node. Hence, we have many edge pairs that look
         # like [x, y], [y, x]. We solve this by sorting and calling np.unique
         # row-wise
         if make_unique and len(edges) > 0:
-            edges, idx = np.unique(np.sort(edges, axis=1), axis=0,
-                                   return_index=True)
+            edges, idx = np.unique(np.sort(edges, axis=1), axis=0, return_index=True)
             affinities = affinities[idx]
             areas = areas[idx]
 
@@ -3597,7 +4119,7 @@ class ChunkedGraph(object):
         sink_coord: Sequence[int] = None,
         n_tries: int = 60,
     ) -> GraphEditOperation.Result:
-        """ Adds an edge to the chunkedgraph
+        """Adds an edge to the chunkedgraph
 
             Multi-user safe through locking of the root node
 
@@ -3637,7 +4159,7 @@ class ChunkedGraph(object):
         bb_offset: Tuple[int, int, int] = (240, 240, 24),
         n_tries: int = 20,
     ) -> GraphEditOperation.Result:
-        """ Removes edges - either directly or after applying a mincut
+        """Removes edges - either directly or after applying a mincut
 
             Multi-user safe through locking of the root node
 
@@ -3689,31 +4211,41 @@ class ChunkedGraph(object):
             sink_coords=sink_coords,
         ).execute()
 
-    def undo_operation(self, user_id: str, operation_id: np.uint64) -> GraphEditOperation.Result:
-        """ Applies the inverse of a previous GraphEditOperation
+    def undo_operation(
+        self, user_id: str, operation_id: np.uint64
+    ) -> GraphEditOperation.Result:
+        """Applies the inverse of a previous GraphEditOperation
 
         :param user_id: str
         :param operation_id: operation_id to be inverted
         :return: GraphEditOperation.Result
         """
-        return GraphEditOperation.undo_operation(self, user_id=user_id, operation_id=operation_id, multicut_as_split=True).execute()
+        return GraphEditOperation.undo_operation(
+            self, user_id=user_id, operation_id=operation_id, multicut_as_split=True
+        ).execute()
 
-    def redo_operation(self, user_id: str, operation_id: np.uint64) -> GraphEditOperation.Result:
-        """ Re-applies a previous GraphEditOperation
+    def redo_operation(
+        self, user_id: str, operation_id: np.uint64
+    ) -> GraphEditOperation.Result:
+        """Re-applies a previous GraphEditOperation
 
         :param user_id: str
         :param operation_id: operation_id to be repeated
         :return: GraphEditOperation.Result
         """
-        return GraphEditOperation.redo_operation(self, user_id=user_id, operation_id=operation_id, multicut_as_split=True).execute()
+        return GraphEditOperation.redo_operation(
+            self, user_id=user_id, operation_id=operation_id, multicut_as_split=True
+        ).execute()
 
-    def _run_multicut(self, source_ids: Sequence[np.uint64],
-                      sink_ids: Sequence[np.uint64],
-                      source_coords: Sequence[Sequence[int]],
-                      sink_coords: Sequence[Sequence[int]],
-                      bb_offset: Tuple[int, int, int] = (120, 120, 12),
-                      split_preview: bool = False):
-
+    def _run_multicut(
+        self,
+        source_ids: Sequence[np.uint64],
+        sink_ids: Sequence[np.uint64],
+        source_coords: Sequence[Sequence[int]],
+        sink_coords: Sequence[Sequence[int]],
+        bb_offset: Tuple[int, int, int] = (120, 120, 12),
+        split_preview: bool = False,
+    ):
 
         time_start = time.time()
 
@@ -3740,15 +4272,18 @@ class ChunkedGraph(object):
                 f"All supervoxel must belong to the same object. Already split?"
             )
 
-        self.logger.debug("Get roots and check: %.3fms" %
-                          ((time.time() - time_start) * 1000))
+        self.logger.debug(
+            "Get roots and check: %.3fms" % ((time.time() - time_start) * 1000)
+        )
         time_start = time.time()  # ------------------------------------------
 
         root_id = root_ids.pop()
 
         # Get edges between local supervoxels
-        n_chunks_affected = np.product((np.ceil(bounding_box[1] / self.chunk_size)).astype(np.int) -
-                                       (np.floor(bounding_box[0] / self.chunk_size)).astype(np.int))
+        n_chunks_affected = np.product(
+            (np.ceil(bounding_box[1] / self.chunk_size)).astype(np.int)
+            - (np.floor(bounding_box[0] / self.chunk_size)).astype(np.int)
+        )
 
         self.logger.debug("Number of affected chunks: %d" % n_chunks_affected)
         self.logger.debug(f"Bounding box: {bounding_box}")
@@ -3757,28 +4292,29 @@ class ChunkedGraph(object):
         self.logger.debug(f"Sink ids: {sink_ids}")
         self.logger.debug(f"Root id: {root_id}")
 
-        edges, affs, areas = self.get_subgraph_edges(root_id,
-                                                     bounding_box=bounding_box,
-                                                     bb_is_coordinate=True)
-        self.logger.debug(f"Get edges and affs: "
-                          f"{(time.time() - time_start) * 1000:.3f}ms")
+        edges, affs, areas = self.get_subgraph_edges(
+            root_id, bounding_box=bounding_box, bb_is_coordinate=True
+        )
+        self.logger.debug(
+            f"Get edges and affs: " f"{(time.time() - time_start) * 1000:.3f}ms"
+        )
 
         time_start = time.time()  # ------------------------------------------
 
         if len(edges) == 0:
             raise cg_exceptions.PreconditionError(
-                f"No local edges found. "
-                f"Something went wrong with the bounding box?"
+                f"No local edges found. " f"Something went wrong with the bounding box?"
             )
 
         # Compute mincut
-        atomic_edges = cutting.mincut(edges, affs, source_ids, sink_ids, split_preview=split_preview)
+        atomic_edges = cutting.mincut(
+            edges, affs, source_ids, sink_ids, split_preview=split_preview
+        )
 
         self.logger.debug(f"Mincut: {(time.time() - time_start) * 1000:.3f}ms")
 
         if len(atomic_edges) == 0:
-            raise cg_exceptions.PostconditionError(
-                f"Mincut failed. Try again...")
+            raise cg_exceptions.PostconditionError(f"Mincut failed. Try again...")
 
         # # Check if any edge in the cutset is infinite (== between chunks)
         # # We would prevent such a cut
@@ -3794,7 +4330,9 @@ class ChunkedGraph(object):
 
         return atomic_edges
 
-    def get_first_shared_parent(self, first_node_id: np.uint64, second_node_id: np.uint64):
+    def get_first_shared_parent(
+        self, first_node_id: np.uint64, second_node_id: np.uint64
+    ):
         """
         Get the common parent of first_node_id and second_node_id with the lowest layer.
         Returns None if the two nodes belong to different root ids.
@@ -3848,17 +4386,17 @@ class ChunkedGraph(object):
             if not np.any(nodes_to_query):
                 break
         return np.concatenate(children_at_layer)
-        
+
     def get_chunk_voxel_location(self, chunk_coordinate):
         """
         Given a lvl1 or lvl2 chunk coordinate, return the voxel location of the chunk in the
         underlying dataset.
         """
         # TODO: remove this hack once pinky re-built
-        if self._table_id == 'pinky100_sv16':
+        if self._table_id == "pinky100_sv16":
             offset = 0
         else:
-            offset = self.vx_vol_bounds[:,0]
+            offset = self.vx_vol_bounds[:, 0]
         return np.array((offset + self.chunk_size * chunk_coordinate), dtype=np.int)
 
     def download_chunk_segmentation(self, chunk_coordinate):
@@ -3874,21 +4412,28 @@ class ChunkedGraph(object):
         ].squeeze()
         return ws_seg
 
-    def get_proofread_root_ids(self,            
-                               start_time: Optional[datetime.datetime] = None,
-                               end_time: Optional[datetime.datetime] = None):
+    def get_proofread_root_ids(
+        self,
+        start_time: Optional[datetime.datetime] = None,
+        end_time: Optional[datetime.datetime] = None,
+    ):
         log_entries = self.read_log_rows(start_time=start_time, end_time=end_time)
-        new_roots = np.concatenate([e[column_keys.OperationLogs.RootID] 
-                                    for e in log_entries.values()])
-        root_rows = self.read_node_id_rows(node_ids=new_roots,
-                                            columns=[column_keys.Hierarchy.FormerParent])
-        old_roots = np.concatenate([e[column_keys.Hierarchy.FormerParent][0].value 
-                                    for e in root_rows.values()])
+        new_roots = np.concatenate(
+            [e[column_keys.OperationLogs.RootID] for e in log_entries.values()]
+        )
+        root_rows = self.read_node_id_rows(
+            node_ids=new_roots, columns=[column_keys.Hierarchy.FormerParent]
+        )
+        old_roots = np.concatenate(
+            [e[column_keys.Hierarchy.FormerParent][0].value for e in root_rows.values()]
+        )
 
         return old_roots, new_roots
 
     def get_node_timestamps(self, node_ids: Sequence[np.uint64]):
-        children = self.read_node_id_rows(node_ids=node_ids, columns=column_keys.Hierarchy.Child)
+        children = self.read_node_id_rows(
+            node_ids=node_ids, columns=column_keys.Hierarchy.Child
+        )
         if not children:
             return []
         return [children[x][0].timestamp for x in node_ids]

--- a/pychunkedgraph/backend/chunkedgraph.py
+++ b/pychunkedgraph/backend/chunkedgraph.py
@@ -1437,7 +1437,7 @@ class ChunkedGraph(object):
                 root_ids = [root_ids]
 
             if not self.check_and_renew_root_locks(root_ids, operation_id):
-                raise cg_exceptions.LockError(
+                raise cg_exceptions.LockingError(
                     f"Root lock renewal failed for operation ID {operation_id}"
                 )
 

--- a/pychunkedgraph/backend/chunkedgraph.py
+++ b/pychunkedgraph/backend/chunkedgraph.py
@@ -3652,13 +3652,14 @@ class ChunkedGraph(object):
 
     def get_subgraph_nodes(
         self,
-        agglomeration_id: np.uint64,
+        agglomeration_id_or_ids: Union[np.uint64, Iterable[np.uint64]],
         bounding_box: Optional[Sequence[Sequence[int]]] = None,
         bb_is_coordinate: bool = False,
         return_layers: List[int] = [1],
-        verbose: bool = True,
+        verbose: bool = False,
+        serializable: bool = False,
     ) -> Union[Dict[int, np.ndarray], np.ndarray]:
-        """Return all nodes belonging to the specified agglomeration ID within
+        """Return all nodes belonging to the specified agglomeration IDs within
             the defined bounding box and requested layers.
         :param agglomeration_id_or_ids: Union[np.uint64, Iterable[np.uint64]]
         :param bounding_box: [[x_l, y_l, z_l], [x_h, y_h, z_h]]
@@ -3669,8 +3670,6 @@ class ChunkedGraph(object):
                  Dict[int, np.array] if multiple layers are requested
         """
 
-        """Get the children of the specified node_ids that are at each of the specified
-        return_layers within the specified bounding box."""
         single = False
         node_ids = agglomeration_id_or_ids
         bbox = self.normalize_bounding_box(bounding_box, bb_is_coordinate)


### PR DESCRIPTION
This PR is overhauling how supervoxel ids are derived from coordinates (and a parent id). Currently, we are seeing many errors because supervoxel ids cannot be found. The new approach supports parallel lookup of many coordinates and heuristically groups coordinates before lookups. It is more robust against failures by iterating through a list of maximal allowable distances. Tested on the fly sandbox and it works well.