### PR TITLE
get leaves fix + configurable row count

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -673,13 +673,11 @@ def handle_leaves(table_id, root_id):
             int(root_id),
             bbox=bounding_box,
             bbox_is_coordinate=True,
-            return_layers=[stop_layer]
+            return_layers=[stop_layer],
+            return_flattened=True
         )
-        result = [empty_1d]
-        for node_subgraph in subgraph.values():
-            for children_at_layer in node_subgraph.values():
-                result.append(children_at_layer)
-        return np.concatenate(result)
+
+        return subgraph
     return cg.get_subgraph_leaves(
         int(root_id),
         bbox=bounding_box,

--- a/pychunkedgraph/graph/client/bigtable/__init__.py
+++ b/pychunkedgraph/graph/client/bigtable/__init__.py
@@ -9,6 +9,7 @@ _bigtableconfig_fields = (
     "ADMIN",
     "READ_ONLY",
     "CREDENTIALS",
+    "MAX_ROW_KEY_COUNT"
 )
 _bigtableconfig_defaults = (
     DEFAULT_PROJECT,
@@ -16,6 +17,7 @@ _bigtableconfig_defaults = (
     False,
     True,
     None,
+    1000
 )
 BigTableConfig = namedtuple(
     "BigTableConfig", _bigtableconfig_fields, defaults=_bigtableconfig_defaults

--- a/pychunkedgraph/tests/helpers.py
+++ b/pychunkedgraph/tests/helpers.py
@@ -130,6 +130,7 @@ def gen_graph(request):
                     "PROJECT": "IGNORE_ENVIRONMENT_PROJECT",
                     "INSTANCE": "emulated_instance",
                     "CREDENTIALS": credentials.AnonymousCredentials(),
+                    "MAX_ROW_KEY_COUNT": 1000
                 },
             },
             "ingest_config": {},


### PR DESCRIPTION
This adds a configuration for max_row_count in the bigtable client (and changes the default to 1000).

It also has a fix for get_leaves with stop_layer which was not working becuase the format wasn't consisstent in unpacking the resullts of the bigtable query.  Using the flatten option simplified thing.  One can look up what level things are from via the nodeId.