### PR TITLE
Don't include undone operations in all_user_operations

### DIFF
--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -168,7 +168,8 @@ def handle_rollback(table_id):
 @auth_requires_permission("admin_view")
 def handle_user_operations(table_id):
     disp = request.args.get("disp", default=False, type=toboolean)
-    user_operations = pd.DataFrame.from_dict(common.all_user_operations(table_id))
+    include_undone = request.args.get("include_undone", default=False, type=toboolean)
+    user_operations = pd.DataFrame.from_dict(common.all_user_operations(table_id, include_undone))
 
     if disp:
         return user_operations.to_html()


### PR DESCRIPTION
The rollback uses all_user_operations, so this will cause them to be skipped in the rollback as well (allowing for multiple rollbacks if one throws an error).