### PR TITLE
fixing handle_root_timestamps

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -1211,7 +1211,7 @@ def handle_root_timestamps(table_id, is_binary):
     # Call ChunkedGraph
     cg = app_utils.get_cg(table_id)
 
-    timestamps = cg.get_node_timestamps(node_ids)
+    timestamps = cg.get_node_timestamps(node_ids, return_numpy=False)
     return [ts.timestamp() for ts in timestamps]
 
 


### PR DESCRIPTION
this endpoint was broken because of the default return numpy behavior