### PR TITLE
Remap public fixes

### DIFF
--- a/pychunkedgraph/app/app_utils.py
+++ b/pychunkedgraph/app/app_utils.py
@@ -69,6 +69,7 @@ def remap_public(func=None, *, edit=False, check_node_ids=False):
                 def ceiling_timestamp(argname):
                     old_arg = http_args.get(argname, None)
                     if old_arg is not None:
+                        old_arg = float(old_arg)
                         # if they specified a timestamp
                         # enforce its less than the cap
                         if old_arg > v_timetamp_float:

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -9,7 +9,12 @@ from middle_auth_client import auth_requires_permission
 from middle_auth_client import auth_requires_admin
 from middle_auth_client import auth_required
 
-from pychunkedgraph.app.app_utils import jsonify_with_kwargs, toboolean, tobinary, remap_public
+from pychunkedgraph.app.app_utils import (
+    jsonify_with_kwargs,
+    toboolean,
+    tobinary,
+    remap_public,
+)
 from pychunkedgraph.app.segmentation import common
 from pychunkedgraph.graph import exceptions as cg_exceptions
 
@@ -177,7 +182,9 @@ def handle_rollback(table_id):
 def handle_user_operations(table_id):
     disp = request.args.get("disp", default=False, type=toboolean)
     include_undone = request.args.get("include_undone", default=False, type=toboolean)
-    user_operations = pd.DataFrame.from_dict(common.all_user_operations(table_id, include_undone))
+    user_operations = pd.DataFrame.from_dict(
+        common.all_user_operations(table_id, include_undone)
+    )
 
     if disp:
         return user_operations.to_html()
@@ -487,7 +494,6 @@ def find_path(table_id):
 ### ROOT INFO -----------------------------------------------------------------
 
 
-
 @bp.route("/table/<table_id>/is_latest_roots", methods=["POST"])
 @auth_requires_permission("view")
 @remap_public(edit=False)
@@ -501,6 +507,7 @@ def handle_is_latest_roots(table_id):
 
 @bp.route("/table/<table_id>/root_timestamps", methods=["POST"])
 @auth_requires_permission("view")
+@remap_public(edit=False)
 def handle_root_timestamps(table_id):
     int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     is_binary = request.args.get("is_binary", default=False, type=toboolean)
@@ -549,6 +556,7 @@ def operation_details(table_id):
 
 @bp.route("/table/<table_id>/delta_roots", methods=["GET"])
 @auth_requires_permission("view")
+@remap_public(edit=False)
 def delta_roots(table_id):
     int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     resp = common.delta_roots(table_id)


### PR DESCRIPTION
The timestamp capping wasn't working when a timestamp was passed, and remap public was missing from some new endpoints.