### PR TITLE
fixing mesh directory to be read from custom_data

### DIFF
--- a/pychunkedgraph/graph/chunkedgraph.py
+++ b/pychunkedgraph/graph/chunkedgraph.py
@@ -79,6 +79,10 @@ class ChunkedGraph:
     def cache(self):
         return self._cache_service
 
+    @property
+    def segmentation_resolution(self) -> np.ndarray:
+        return np.array(self.meta.ws_cv.scale["resolution"])
+
     @cache.setter
     def cache(self, cache_service: CacheService):
         self._cache_service = cache_service

--- a/pychunkedgraph/graph/meta.py
+++ b/pychunkedgraph/graph/meta.py
@@ -210,6 +210,7 @@ class ChunkedGraphMeta:
     @property
     def dataset_info(self) -> Dict:
         info = self.ws_cv.info  # pylint: disable=no-member
+
         info.update(
             {
                 "chunks_start_at_voxel_offset": True,
@@ -224,6 +225,13 @@ class ChunkedGraphMeta:
                 },
             }
         )
+        mesh_dir = self.custom_data.get("mesh", {}).get("dir", None)
+        if mesh_dir is not None:
+            info.update(
+                {
+                    "mesh": mesh_dir
+                }
+            )
         return info
 
     def __getnewargs__(self):


### PR DESCRIPTION
the dataset_info was not reading the custom_data property and defaulting to what was in the info file, not allowing customization of mesh directories, which made where the pcg was reading and writing meshes to be different.