### PR TITLE
add undo_info parameter to tabular changelog

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -905,7 +905,7 @@ def tabular_change_logs(table_id, root_ids, filtered=False, undo_info=False):
                 row = undone_ids[np.where(undone_ids[:, 0] == id)]
                 if len(row) > 0:
                     return row[0][1]
-                return None
+                return ""
             undone_by = np.array(list(map(get_undone_by, operation_ids)))
             tab[tab_k]["undone_by"] = undone_by
 

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -406,7 +406,8 @@ def tabular_change_log(table_id, root_id):
     disp = request.args.get("disp", default=False, type=toboolean)
     get_root_ids = request.args.get("root_ids", default=False, type=toboolean)
     filtered = request.args.get("filtered", default=True, type=toboolean)
-    tab_change_log_dict = common.tabular_change_logs(table_id, [int(root_id)], filtered)
+    undo_info = request.args.get("undo_info", default=False, type=toboolean)
+    tab_change_log_dict = common.tabular_change_logs(table_id, [int(root_id)], filtered, undo_info)
     tab_change_log = tab_change_log_dict[int(root_id)]
     if disp:
         return tab_change_log.to_html()
@@ -420,8 +421,9 @@ def tabular_change_log_many(table_id):
     import numpy as np
 
     filtered = request.args.get("filtered", default=True, type=toboolean)
+    undo_info = request.args.get("undo_info", default=False, type=toboolean)
     root_ids = np.array(json.loads(request.data)["root_ids"], dtype=np.uint64)
-    tab_change_log_dict = common.tabular_change_logs(table_id, root_ids, filtered)
+    tab_change_log_dict = common.tabular_change_logs(table_id, root_ids, filtered, undo_info)
 
     return jsonify_with_kwargs(
         {str(k): tab_change_log_dict[k] for k in tab_change_log_dict.keys()}


### PR DESCRIPTION
By setting `undo_info=1` in calls to `tabular_change_log` or `tabular_change_log_many`, two new columns will be added to the result: `is_undo` and `undone_by`. `is_undo` contains `undo`, `redo`, or the empty string, depending on what type of operation it is. `undone_by` contains either the ID of the operation that undid it (if it has been undone), or the empty string (if not).

This parameter is set to false by default, since it is a somewhat expensive operation (in order to associate edits with their undos, it needs to loop through every edit in the dataset).