### PR TITLE
refactor: compatibility with future zmesh upgrade

### DIFF
--- a/pychunkedgraph/meshing/meshgen.py
+++ b/pychunkedgraph/meshing/meshgen.py
@@ -1019,7 +1019,9 @@ def chunk_mesh_task_new_remapping(
                     max_simplification_error=max_err,
                 )
                 mesher.erase(obj_id)
-                mesh.vertices[:] += chunk_offset
+                mesh.vertices[:] += chunk_offset 
+                # backwards compatibility with zmesh 1.0.0
+                mesh.vertices[:] -= 0.5 * cg.cv.mip_resolution(mip) 
                 if encoding == "draco":
                     try:
                         file_contents = DracoPy.encode_mesh_to_buffer(

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ redis
 rq
 middle-auth-client>=3.6.4
 dracopy<=0.0.19
-zmesh
+zmesh~=1.0.0
 fastremap
 contact-points
 messagingclient


### PR DESCRIPTION
Zmesh was offsetting meshes by 0.5 voxels. In version 1.0.0,
zmesh will fix this. To ensure backwards compatibility of PCG
meshes, we reapply the "error".

1.0.0 isn't released yet, so do not merge this yet.

https://github.com/seung-lab/zmesh/pull/22
https://github.com/seung-lab/igneous/issues/118
