### PR TITLE
Fix 3d error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ venv.bak/
 *.ipynb
 *.rdb
 /protobuf*
+.DS_Store

--- a/pychunkedgraph/graph/utils/id_helpers.py
+++ b/pychunkedgraph/graph/utils/id_helpers.py
@@ -161,6 +161,7 @@ def get_atomic_ids_from_coords(
         local_sv_ids,
         time_stamp=parent_ts,
         stop_layer=parent_id_layer,
+        fail_to_zero=True
     )
 
     local_parent_seg = fastremap.remap(

--- a/pychunkedgraph/logging/flask_log_db.py
+++ b/pychunkedgraph/logging/flask_log_db.py
@@ -5,8 +5,8 @@ from google.cloud import datastore
 HOME = os.path.expanduser('~')
 
 # Setting environment wide credential path
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = \
-           HOME + "/.cloudvolume/secrets/google-secret.json"
+#os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = \
+#           HOME + "/.cloudvolume/secrets/google-secret.json"
 
 
 class FlaskLogDatabase(object):


### PR DESCRIPTION
we tracked down a bug in minnie related to  timestamps of original root_ids that leads to the timestamp of those IDs being too old and the supervoxels of the nodes of other original ids being slightly newer, and thus get_roots fails in cutouts without fail_to_zero.   here's an example from minnie to illustrate... if you run this you'll get a bunch of root_ids=0, but if you remove the timestamp filter you will get root_ids for all of them. 

```old_time=client.chunkedgraph.get_root_timestamps(864691135677617710)[0]

svids=[107314878901080533, 107314878901080735, 107314878901082109,
       107314878901086726, 107314878901086731, 107314878901086808,
       107314878901087766, 107314878901087945, 107314878901087953,
       107314878901092680, 107314878901094945, 107314878901094959,
       107314878901094963, 107314878901095527, 107314878901097212,
       107314878901098342, 107314878901098442, 107314878901098455,
       107314878901098464, 107314878901099835, 107314878901100645,
       107314878901100684, 107314878901100766, 107314878901101792,
       107314878901101925, 107314878901102071, 107314878901102077,
       107314878901102143, 107314878901103113, 107314878901103329,
       107314878901103342, 107314878901104741, 107314878901105879,
       107314878901106045, 107314878901107320, 107314878901107347,
       107314878901107371, 107314878901108365, 107314878901108422,
       107314878901108567, 107314878901109400, 107314878901109560,
       107314878901111119, 107314878901111216, 107314878901111325,
       107314878901111331, 107314878901112192, 107314878901112348,
       107314878901112360, 107314878901112385, 107314878901113111,
       107314878901114335, 107314878901115644, 107314878901115654,
       107314878901115678, 107314878901115711, 107314878901116841,
       107314878901117699, 107385247645260117, 107385247645261124,
       107385247645263256, 107385247645263919, 107385247645263923,
       107385247645264235, 107385247645266168, 107385247645266169,
       107385247645269985, 107385247645270334, 107385247645273084,
       107385247645282629]

root_ids=client.chunkedgraph.get_roots(svids, timestamp=old_time)
```