### PR TITLE
fixing merge with skip connections

### DIFF
--- a/pychunkedgraph/debug/cross_edge_test.py
+++ b/pychunkedgraph/debug/cross_edge_test.py
@@ -5,7 +5,7 @@ import numpy as np
 from pychunkedgraph.graph import chunkedgraph
 from pychunkedgraph.graph import attributes
 
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] =  "/home/svenmd/.cloudvolume/secrets/google-secret.json"
+#os.environ["GOOGLE_APPLICATION_CREDENTIALS"] =  "/home/svenmd/.cloudvolume/secrets/google-secret.json"
 
 layer = 2
 n_chunks = 1000

--- a/pychunkedgraph/debug/existence_test.py
+++ b/pychunkedgraph/debug/existence_test.py
@@ -5,7 +5,7 @@ import numpy as np
 from pychunkedgraph.graph import chunkedgraph
 from pychunkedgraph.graph import attributes
 
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] =  "/home/svenmd/.cloudvolume/secrets/google-secret.json"
+#os.environ["GOOGLE_APPLICATION_CREDENTIALS"] =  "/home/svenmd/.cloudvolume/secrets/google-secret.json"
 
 layer = 2
 n_chunks = 100

--- a/pychunkedgraph/debug/family_test.py
+++ b/pychunkedgraph/debug/family_test.py
@@ -5,7 +5,7 @@ import numpy as np
 from pychunkedgraph.graph import chunkedgraph
 from pychunkedgraph.graph import attributes
 
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] =  "/home/svenmd/.cloudvolume/secrets/google-secret.json"
+# os.environ["GOOGLE_APPLICATION_CREDENTIALS"] =  "/home/svenmd/.cloudvolume/secrets/google-secret.json"
 
 layers = [2, 3, 4, 5, 6, 7]
 n_chunks = 10

--- a/pychunkedgraph/graph/edits.py
+++ b/pychunkedgraph/graph/edits.py
@@ -567,7 +567,7 @@ class CreateParentNodes:
                 children = self.cg.get_children(id_)
                 assert np.max(
                     self.cg.get_chunk_layers(children)
-                ) <= self.cg.get_chunk_layer(id_), "Parent layer less than children."
+                ) < self.cg.get_chunk_layer(id_), "Parent layer less than children."
                 val_dict[attributes.Hierarchy.Child] = children
                 rows.append(
                     self.cg.client.mutate_row(


### PR DESCRIPTION
I think this solves a bug with doing merges that include skip connections, we don't want to be reassigning parents of lower level ids in the new parents run, so when including those skip connection edges, we need to remap any edges discovered in this way from the lower IDs to their appropriate parent at the current level of the hierarchy. 