### PR TITLE
fix: when mesh metadata is missing

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -93,9 +93,13 @@ def handle_info(table_id):
     combined_info["verify_mesh"] = cg.meta.custom_data.get("mesh", {}).get(
         "verify", False
     )
-    combined_info["mesh"] = cg.meta.custom_data.get("mesh", {}).get(
-        "dir", "graphene_meshes"
+    mesh_dir = cg.meta.custom_data.get("mesh", {}).get(
+        "dir", None
     )
+    if mesh_dir is not None:
+        combined_info["mesh_dir"] = mesh_dir
+    elif combined_info.get("mesh_dir", None) is not None:
+        combined_info["mesh_dir"] = "graphene_meshes"
     return jsonify(combined_info)
 
 

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -458,6 +458,7 @@ def handle_lineage_graph(table_id, root_id):
 
 @bp.route("/table/<table_id>/lineage_graph_multiple", methods=["POST"])
 @auth_requires_permission("view")
+@remap_public(edit=False)
 def handle_lineage_graph_multiple(table_id):
     int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     resp = common.handle_lineage_graph(table_id)
@@ -592,6 +593,7 @@ def delta_roots(table_id):
 
 @bp.route("/table/<table_id>/valid_nodes", methods=["GET"])
 @auth_requires_permission("view")
+@remap_public(edit=False)
 def valid_nodes(table_id):
     int64_as_str = request.args.get("int64_as_str", default=False, type=toboolean)
     is_binary = request.args.get("is_binary", default=False, type=toboolean)

--- a/pychunkedgraph/app/segmentation/v1/routes.py
+++ b/pychunkedgraph/app/segmentation/v1/routes.py
@@ -427,6 +427,7 @@ def tabular_change_log(table_id, root_id):
 
 @bp.route("/table/<table_id>/tabular_change_log_many", methods=["GET"])
 @auth_requires_permission("view")
+@remap_public(edit=False)
 def tabular_change_log_many(table_id):
     filtered = request.args.get("filtered", default=True, type=toboolean)
     root_ids = np.array(json.loads(request.data)["root_ids"], dtype=np.uint64)

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ cloud-volume==6.1.1
     # via
     #   -r requirements.in
     #   task-queue
-codecov==2.1.12
+codecov==2.1.13
     # via -r requirements.in
 compressed-segmentation==2.2.0
     # via cloud-volume


### PR DESCRIPTION
When the watershed layer was specifying a different mesh directory, the mesh worker was using cg.meta.dataset_info to determine where the meshes were being written to, but the info file generated assumed that the mesh_dir was in the mesh custom metadata.  If it was not there, it overwrote the location to the default graphene_meshes location. For the pinky_sandbox, there was a mismatch between the watershed info file mesh directory location and then there was nothing specific in the mesh metadata, so it fell back to graphene_meshes, which is not where meshes were being written to. 