### PR TITLE
performance: Edge initialization

### DIFF
--- a/pychunkedgraph/graph/edges/__init__.py
+++ b/pychunkedgraph/graph/edges/__init__.py
@@ -30,21 +30,21 @@ class Edges:
         areas: Optional[np.ndarray] = None,
         fake_edges=False,
     ):
-        self.node_ids1 = np.array(node_ids1, dtype=basetypes.NODE_ID)
-        self.node_ids2 = np.array(node_ids2, dtype=basetypes.NODE_ID)
+        self.node_ids1 = np.array(node_ids1, dtype=basetypes.NODE_ID, copy=False)
+        self.node_ids2 = np.array(node_ids2, dtype=basetypes.NODE_ID, copy=False)
         assert self.node_ids1.size == self.node_ids2.size
 
         self._as_pairs = None
         self._fake_edges = fake_edges
 
         if affinities is not None and len(affinities) > 0:
-            self._affinities = np.array(affinities, dtype=basetypes.EDGE_AFFINITY)
+            self._affinities = np.array(affinities, dtype=basetypes.EDGE_AFFINITY, copy=False)
             assert self.node_ids1.size == self._affinities.size
         else:
             self._affinities = np.full(len(self.node_ids1), DEFAULT_AFFINITY)
 
         if areas is not None and len(areas) > 0:
-            self._areas = np.array(areas, dtype=basetypes.EDGE_AREA)
+            self._areas = np.array(areas, dtype=basetypes.EDGE_AREA, copy=False)
             assert self.node_ids1.size == self._areas.size
         else:
             self._areas = np.full(len(self.node_ids1), DEFAULT_AREA)

--- a/pychunkedgraph/graph/edges/__init__.py
+++ b/pychunkedgraph/graph/edges/__init__.py
@@ -33,18 +33,21 @@ class Edges:
         self.node_ids1 = np.array(node_ids1, dtype=basetypes.NODE_ID)
         self.node_ids2 = np.array(node_ids2, dtype=basetypes.NODE_ID)
         assert self.node_ids1.size == self.node_ids2.size
-        self._affinities = np.ones(len(self.node_ids1)) * DEFAULT_AFFINITY
-        self._areas = np.ones(len(self.node_ids1)) * DEFAULT_AREA
+
         self._as_pairs = None
         self._fake_edges = fake_edges
 
         if affinities is not None and len(affinities) > 0:
             self._affinities = np.array(affinities, dtype=basetypes.EDGE_AFFINITY)
             assert self.node_ids1.size == self._affinities.size
+        else:
+            self._affinities = np.full(len(self.node_ids1), DEFAULT_AFFINITY)
 
         if areas is not None and len(areas) > 0:
             self._areas = np.array(areas, dtype=basetypes.EDGE_AREA)
             assert self.node_ids1.size == self._areas.size
+        else:
+            self._areas = np.full(len(self.node_ids1), DEFAULT_AREA)
 
     @property
     def affinities(self) -> np.ndarray:


### PR DESCRIPTION
Proposed changes:
* only set `self._affinities` and `self._areas` if they are not provided
* `np.array(` will only create copies if necessary (e.g. because the data type is not what it should be)

The second one might be a bit risky? Depending on what the original, intended behavior was: the default behavior for `np.array` in `__init__` is to always create a copy, but the current setters are only updating the reference