### PR TITLE
Python 3.11 migrations

### DIFF
--- a/pychunkedgraph/app/__init__.py
+++ b/pychunkedgraph/app/__init__.py
@@ -9,6 +9,7 @@ import pandas as pd
 import numpy as np
 import redis
 from flask import Flask
+from flask.json.provider import DefaultJSONProvider
 from flask.logging import default_handler
 from flask_cors import CORS
 from rq import Queue
@@ -45,13 +46,18 @@ class CustomJsonEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
+class CustomJSONProvider(DefaultJSONProvider):
+    def dumps(self, obj, **kwargs):
+        return super().dumps(obj, default=None, cls=CustomJsonEncoder, **kwargs)
+
+
 def create_app(test_config=None):
     app = Flask(
         __name__,
         instance_path=get_instance_folder_path(),
         instance_relative_config=True,
     )
-    app.json_encoder = CustomJsonEncoder
+    app.json = CustomJSONProvider(app)
 
     CORS(app, expose_headers="WWW-Authenticate")
 

--- a/pychunkedgraph/app/app_utils.py
+++ b/pychunkedgraph/app/app_utils.py
@@ -124,14 +124,14 @@ def remap_public(func=None, *, edit=False, check_node_ids=False):
 def jsonify_with_kwargs(data, as_response=True, **kwargs):
     kwargs.setdefault("separators", (",", ":"))
 
-    if current_app.config["JSONIFY_PRETTYPRINT_REGULAR"] or current_app.debug:
+    if current_app.json.compact == False or current_app.debug:
         kwargs["indent"] = 2
         kwargs["separators"] = (", ", ": ")
 
     resp = json.dumps(data, **kwargs)
     if as_response:
         return current_app.response_class(
-            resp + "\n", mimetype=current_app.config["JSONIFY_MIMETYPE"]
+            resp + "\n", mimetype=current_app.json.mimetype
         )
     else:
         return resp

--- a/pychunkedgraph/app/common.py
+++ b/pychunkedgraph/app/common.py
@@ -91,7 +91,7 @@ def unhandled_exception(e):
     status_code = 500
     response_time = (time.time() - current_app.request_start_time) * 1000
     user_ip = str(request.remote_addr)
-    tb = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
+    tb = traceback.format_exception(e)
 
     _log_request(response_time)
 
@@ -123,7 +123,7 @@ def unhandled_exception(e):
 def api_exception(e):
     response_time = (time.time() - current_app.request_start_time) * 1000
     user_ip = str(request.remote_addr)
-    tb = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
+    tb = traceback.format_exception(e)
 
     _log_request(response_time)
 


### PR DESCRIPTION
* Py3.10: [traceback.print_exception(exc, /, [value, tb, ]limit=None, file=None, chain=True)](https://docs.python.org/3.10/library/traceback.html#traceback.print_exception)
* Flask: `app.json_encoder`, `JSONIFY_MIMETYPE`, and `JSONIFY_PRETTYPRINT_REGULAR` were removed in 2.3.0. Now using the new `JSONProvider` interface introduced in [flask 2.2.0](https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-2-0)