### PR TITLE
More Python 3.11 + dependency upgrade related stuff

### DIFF
--- a/pychunkedgraph/meshing/meshgen.py
+++ b/pychunkedgraph/meshing/meshgen.py
@@ -967,7 +967,7 @@ def chunk_initial_mesh_task(
         black_out_dust_from_segmentation(seg, dust_threshold)
     if return_frag_count:
         return np.unique(seg).shape[0]
-    mesher.mesh(seg.T)
+    mesher.mesh(seg)
     del seg
     cf = CloudFiles(mesh_dst)
     if PRINT_FOR_DEBUGGING:

--- a/pychunkedgraph/meshing/meshgen.py
+++ b/pychunkedgraph/meshing/meshgen.py
@@ -1036,7 +1036,7 @@ def get_multi_child_nodes(cg, chunk_id, node_id_subset=None, chunk_bbox_string=F
             fragment.value
             for child_fragments_for_node in node_rows
             for fragment in child_fragments_for_node
-        ]
+        ], dtype=object
     )
     # Filter out node ids that do not have roots (caused by failed ingest tasks)
     root_ids = cg.get_roots(node_ids, fail_to_zero=True)

--- a/pychunkedgraph/meshing/meshgen_utils.py
+++ b/pychunkedgraph/meshing/meshgen_utils.py
@@ -123,7 +123,9 @@ def get_downstream_multi_child_nodes(
         )
         if np.any(stop_layer_mask):
             node_to_children_dict = cg.get_children(cur_node_ids[stop_layer_mask])
-            children_array = np.array(list(node_to_children_dict.values()))
+            children_array = np.array(
+                list(node_to_children_dict.values()), dtype=object
+            )
             only_child_mask = np.array(
                 [len(children_for_node) == 1 for children_for_node in children_array]
             )


### PR DESCRIPTION
* nonhomogeneous ndarray creation requires `dtype=object`
* zmesh fixed transpose bug - no need for additional transpose