### PR TITLE
Correctly return response in `valid_nodes`

### DIFF
--- a/pychunkedgraph/app/segmentation/common.py
+++ b/pychunkedgraph/app/segmentation/common.py
@@ -1153,4 +1153,4 @@ def valid_nodes(table_id, is_binary):
         node_ids=node_ids, start_time=start_timestamp, end_time=end_timestamp
     )
     resp = {"valid_roots": np.array(list(rows.keys()), dtype=basetypes.NODE_ID)}
-    return
+    return resp


### PR DESCRIPTION
I am guessing this is the cause of https://github.com/seung-lab/CAVEclient/issues/120

Not sure how to test... 