### PR TITLE
Pcgv1 meshfix hack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,2 @@
-# FROM gcr.io/neuromancer-seung-import/pychunkedgraph:graph-tool_dracopy
-FROM seunglab/pychunkedgraph:graph-tool_dracopy
-COPY override/timeout.conf /etc/nginx/conf.d/timeout.conf
-COPY override/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-COPY requirements.txt /app
-RUN pip install --upgrade pip \
-    && pip install --no-cache-dir --upgrade -r requirements.txt
+FROM docker.io/caveconnectome/pychunkedgraph:v1.27.0
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.io/caveconnectome/pychunkedgraph:v1.27.0
+FROM docker.io/caveconnectome/pychunkedgraph:v1.25.0
 COPY . /app

--- a/workers/mesh_worker.py
+++ b/workers/mesh_worker.py
@@ -1,6 +1,24 @@
 from os import getenv
 
 from messagingclient import MessagingClient
+from google.cloud import bigtable
+from google.auth import credentials
+from google.auth import default as default_creds
+from google.cloud import bigtable
+
+class DoNothingCreds(credentials.Credentials):
+    def refresh(self, request):
+        pass
+
+def get_bigtable_client(project_id, emulate=False):
+    if emulate:
+        creds = DoNothingCreds()
+    elif project_id is not None:
+        creds, _ = default_creds()
+    else:
+        creds, project_id = default_creds()
+    client = bigtable.Client(admin=True, project=project_id, credentials=creds)
+    return client
 
 
 def callback(payload):
@@ -24,7 +42,13 @@ def callback(payload):
     logging.info(f"Remeshing {new_lvl2_ids.size} L2 IDs in graph {table_id}")
     logging.info(f"stop_layer={layer}, mip={mip}, max_err={err}")
 
-    cg = ChunkedGraph(table_id)
+    project = getenv("BIGTABLE_PROJECT", "neuromancer-seung-import")
+    instance = getenv("BIGTABLE_INSTANCE", "pychunkedgraph")
+    client = get_bigtable_client(project_id=project)
+    cg=ChunkedGraph(
+        table_id, instance_id=instance, client=client
+    )
+
     meshgen.remeshing(cg, new_lvl2_ids, stop_layer=layer, mip=mip, max_err=err)
     logging.info("Remeshing complete.")
     gc.collect()


### PR DESCRIPTION
This fixes the mesh worker to respect the project configuration of the environment variables, so it doesn't always reference neuromancer-seung-import.  It's a hack in that the build process for v1 is currently broken, so this bases off the last functioning build image and simply copies the python code changes in.