### PR TITLE
Ingest pipeline upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,8 +115,11 @@ venv.bak/
 
 
 # local dev stuff
+*.code-workspace
+.claude/
 .devcontainer/
 *.ipynb
 *.rdb
 /protobuf*
 .DS_Store
+*debug.py

--- a/pychunkedgraph/pipeline/README.md
+++ b/pychunkedgraph/pipeline/README.md
@@ -1,0 +1,105 @@
+# `pipeline` — Kubernetes-native chunk-batch pipeline
+
+Runs chunk-grid workloads — **ingest** and **meshing** — as **one Kubernetes
+Indexed `Job` per layer**, with **no Redis/RQ** and no scheduler add-on. A
+workload-agnostic core (scatter, lock, exit-code contract, worker harness) is
+shared by per-workload subpackages; each is its own container entrypoint:
+
+```
+python -m pychunkedgraph.pipeline.ingest     # ingest worker
+python -m pychunkedgraph.pipeline.meshing     # mesh worker
+```
+
+Self-contained and portable across branches (it depends only on `ChunkedGraph`,
+its Bigtable client, `cg.meta`, and `meshing.meshgen`); the only branch-specific
+piece is the ingest dispatch shim.
+
+## Model
+
+A layer's chunks form an `X·Y·Z` grid of size `N`. The Indexed Job's completion
+index **is** the unit of work — there is no queue. To keep the job count within
+Kubernetes limits at large `N` (10M+ chunks), each index processes a **batch** of
+`B` chunks, so `completions = ceil(N / B)` and `parallelism` = the worker fleet
+width. A pod walks its batch sequentially; ingest runs each chunk under a per-chunk
+lock (one writer per chunk), while many pods run in parallel.
+
+```
+layer L (X·Y·Z = N chunks)
+  └─ Indexed Job: completions = ceil(N/B), parallelism = fleet
+       └─ pod (index i) -> B scattered chunk coords
+            └─ for each chunk: process_one -> ok | done | transient | fatal
+```
+
+**One layer at a time, operator-gated.** Each layer is its own Job; the operator
+launches the next only after the current Job reports `Complete` (resources
+typically need tuning between layers). Nothing auto-advances.
+
+## Layout
+
+| Path | Responsibility |
+|---|---|
+| `grid.py` | Fixed-seed permutation: maps a batch's contiguous index window to *scattered* chunk coords so concurrent workers spread Bigtable row-key load instead of hot-spotting one tablet. Deterministic + invertible. |
+| `exit_codes.py` | Map success / transient / non-transient failure to the Job `podFailurePolicy`. |
+| `lock.py` | Per-chunk Bigtable claim/done cell (atomic CAS). One effective writer per chunk, token-fenced; a dead holder's claim expires so a retry re-claims; already-`done` chunks are skipped. Used by ingest. |
+| `worker.py` | Generic harness `run(make_processor)`: index → coords → loop → exit code. `make_processor(cg, layer, env) -> process_one(coord)`. |
+| `ingest/` | Ingest workload: branch-aware `dispatch` (L2 atomic edges / L>2 agglomeration), `setup` (graph table + meta), `worker` (lock + heartbeat around dispatch). |
+| `meshing/` | Mesh workload: `meta` (`MeshConfig`), `setup` (mesh-metadata, `setup_mesh_meta`), `worker` (marching cubes at L2, sharded stitching above; idempotent, no lock). |
+
+## Setup (run once per workload, before any Jobs)
+
+Each workload has a one-shot setup step that runs the same image and reads the
+dataset yaml from its mounted path (`PCG_DATASET`, not passed):
+
+```
+python -m pychunkedgraph.pipeline.ingest.setup <graph_id> [--raw]   # create table + graph meta
+python -m pychunkedgraph.pipeline.meshing.setup <graph_id>          # write mesh.* metadata (needs `mesh_config:`)
+```
+
+Ingest setup creates the Bigtable table and folds the agglomeration source into
+`meta.custom_data["agg"]`; after it, workers read everything from Bigtable.
+Mesh setup writes the four `mesh.*` fields a graph needs to serve meshes (run once,
+after ingest reaches the root layer), reading a `mesh_config:` block from the yaml.
+
+**Credentials.** GCP clients use Application Default Credentials, so the cleanest
+form is a one-shot in-cluster Job reusing the worker pods' Workload Identity.
+
+## Worker contract (environment)
+
+The Job template sets these on each pod:
+
+| Variable | Meaning |
+|---|---|
+| `JOB_COMPLETION_INDEX` | batch index (set by Kubernetes) |
+| `PCG_GRAPH_ID` | graph id; meta + workload state are read from Bigtable |
+| `PCG_LAYER` | layer being built |
+| `PCG_PERM_SEED` | permutation seed — **same across all pods and retries of a run** |
+| `PCG_BATCH_SIZE` | `B`, chunks per index |
+| `PCG_N_THREADS` | parallel sub-workers inside a parent-chunk build (default 1) |
+| `PCG_LOCK_EXPIRY_SCALE` | (ingest) scales the per-layer claim TTL; default 1 |
+| `PCG_LOCK_POLL_SEC` / `PCG_HELD_MAX_WAIT_SEC` | (ingest) poll interval / max wait before deferring a held chunk |
+| `PCG_MESH_CACHE` | (meshing) `0` disables the mesh task's cloud cache; default on |
+
+## Per-chunk lock (ingest)
+
+Each chunk's lock row holds one of three states — *absent* / *claimed (token +
+expiry)* / *done*. **acquire** succeeds only if neither `done` nor freshly claimed
+elsewhere (an expired claim is stolen); a live worker **renews** in the background so
+its in-progress chunk is never stolen; **mark-done**/**release** are value-matched on
+the claim token (a fence) so a partitioned zombie can't clobber the new owner. On pod
+death mid-batch the finished chunks stay `done`; the retried index skips them and
+re-claims only the unfinished. Meshing needs no lock — it overwrites shards idempotently.
+
+## Failure handling
+
+- **Preemption** (spot reclaim): ignored by the failure policy (off the retry
+  budget); the index is retried.
+- **Transient failure**: counts toward the bounded per-index retry budget; the batch
+  retries (ingest skips done chunks).
+- **Non-transient failure** (`FatalChunkError`, exit 42): the index is failed fast and
+  recorded for inspection. A batch finishes all its chunks before choosing an exit code.
+
+## Testing
+
+- Permutation (`grid`): pure unit tests, no external services — `tests/test_pipeline_grid.py`.
+- Lock / workers: validated against the Bigtable emulator outside the committed suite,
+  so the package stays importable/portable on branches without that fixture.

--- a/pychunkedgraph/pipeline/__init__.py
+++ b/pychunkedgraph/pipeline/__init__.py
@@ -1,0 +1,8 @@
+"""Kubernetes-native chunk-batch pipeline: one Indexed Job per layer, no Redis/RQ.
+
+Workload-agnostic core (``grid`` scatter, ``lock`` per-chunk CAS, ``exit_codes`` Job
+contract, ``worker`` harness) shared by per-workload subpackages (``ingest``,
+``meshing``). Each worker reads its JOB_COMPLETION_INDEX, maps it to a batch of
+scattered chunk coords, and processes each chunk. Self-contained and branch-portable
+(main + pcgv3). Run a workload as a module, e.g. ``python -m pychunkedgraph.pipeline.ingest``.
+"""

--- a/pychunkedgraph/pipeline/exit_codes.py
+++ b/pychunkedgraph/pipeline/exit_codes.py
@@ -1,0 +1,16 @@
+"""Process exit codes mapped to the k8s Job podFailurePolicy.
+
+FATAL is matched by an ``onExitCodes`` ``FailIndex`` rule so a known-bad chunk
+fails its index immediately instead of burning the retry budget; TRANSIENT is an
+ordinary failure that counts toward ``backoffLimitPerIndex``. Preemption needs no
+code here — the kubelet stamps the ``DisruptionTarget`` condition and the
+``Ignore`` rule keeps it off the budget.
+"""
+
+SUCCESS = 0
+TRANSIENT = 1
+FATAL = 42
+
+
+class FatalChunkError(Exception):
+    """Raised for a non-transient chunk failure (bad input/bug, not infra)."""

--- a/pychunkedgraph/pipeline/grid.py
+++ b/pychunkedgraph/pipeline/grid.py
@@ -1,0 +1,126 @@
+"""Deterministic, scattered chunk ordering for the per-layer Indexed Job.
+
+WHY SCATTER. A layer's chunks form an ``X*Y*Z`` grid. In row-major order the
+flat index ``x*(Y*Z) + y*Z + z`` makes consecutive indices spatially-adjacent
+chunks, whose Bigtable row keys (derived from chunk coords) fall in a narrow key
+range. Processing chunks in flat order would point the whole worker fleet at one
+tablet at a time -> a write hotspot. So we never process in flat order.
+
+HOW. k8s hands batch ``i`` the contiguous position window ``[i*B, (i+1)*B)``.
+``permute`` maps each position to a pseudo-random chunk flat-index (a bijection
+over ``[0, N)``), so the chunks one batch touches — and the chunks of all batches
+running at once — spread uniformly across the whole grid / key range.
+
+EXAMPLE (N = 100_000, a 50x50x40 grid, seed = 42). The first eight sequence
+positions map to flat indices spanning 17_224..92_229 — nearly the entire
+``[0, 100_000)`` range — e.g.:
+    pos 0 -> flat 19_165 -> chunk (9, 29, 5)
+    pos 1 -> flat 74_379 -> chunk (37, 9, 19)
+    pos 2 -> flat 92_229 -> chunk (46, 5, 29)
+    pos 3 -> flat 89_707 -> chunk (44, 42, 27)
+    pos 4 -> flat 30_659 -> chunk (15, 16, 19)
+Adjacent positions land far apart, so a single pod's batch — and the fleet as a
+whole — hits scattered tablets rather than one hot range.
+
+PROPERTIES. ``permute`` is a balanced Feistel network with cycle-walking: a true
+bijection over ``[0, N)`` needing no materialized array (scales to billions of
+chunks); a pure function of ``(pos, N, seed)`` so a retry of position i hits the
+exact same chunk; and invertible (``unpermute``) to turn a failed index back into
+its coord for inspection. The seed is pinned per ingest run.
+"""
+
+from typing import List, Sequence, Tuple
+
+import numpy as np
+
+_ROUNDS = 4
+_U64 = 0xFFFFFFFFFFFFFFFF
+
+
+def _splitmix64(z: int) -> int:
+    z = (z + 0x9E3779B97F4A7C15) & _U64
+    z = ((z ^ (z >> 30)) * 0xBF58476D1CE4E5B9) & _U64
+    z = ((z ^ (z >> 27)) * 0x94D049BB133111EB) & _U64
+    return z ^ (z >> 31)
+
+
+def _round_keys(seed: int) -> Tuple[int, ...]:
+    return tuple(_splitmix64(seed + i) for i in range(_ROUNDS))
+
+
+def _half_bits(n: int) -> int:
+    """Half the (even) bit width of the smallest power-of-two domain >= n."""
+    total = max(2, (n - 1).bit_length())
+    return (total + 1) // 2
+
+
+def _mix(value: int, round_key: int, mask: int) -> int:
+    return _splitmix64(value ^ round_key) & mask
+
+
+def _feistel_forward(x: int, half_bits: int, round_keys: Tuple[int, ...]) -> int:
+    mask = (1 << half_bits) - 1
+    left, right = (x >> half_bits) & mask, x & mask
+    for rk in round_keys:
+        left, right = right, left ^ _mix(right, rk, mask)
+    return (left << half_bits) | right
+
+
+def _feistel_inverse(y: int, half_bits: int, round_keys: Tuple[int, ...]) -> int:
+    mask = (1 << half_bits) - 1
+    left, right = (y >> half_bits) & mask, y & mask
+    for rk in reversed(round_keys):
+        left, right = right ^ _mix(left, rk, mask), left
+    return (left << half_bits) | right
+
+
+def permute(pos: int, n: int, seed: int) -> int:
+    """Map sequence position ``pos`` -> a scattered chunk flat-index in ``[0, n)``."""
+    if n <= 1:
+        return 0
+    half_bits, keys = _half_bits(n), _round_keys(seed)
+    x = pos
+    while True:
+        x = _feistel_forward(x, half_bits, keys)
+        if x < n:
+            return x
+
+
+def unpermute(flat: int, n: int, seed: int) -> int:
+    """Inverse of ``permute``: chunk flat-index -> its sequence position."""
+    if n <= 1:
+        return 0
+    half_bits, keys = _half_bits(n), _round_keys(seed)
+    x = flat
+    while True:
+        x = _feistel_inverse(x, half_bits, keys)
+        if x < n:
+            return x
+
+
+def num_batches(n: int, batch_size: int) -> int:
+    return (n + batch_size - 1) // batch_size
+
+
+def batch_coords(
+    batch_index: int, bounds: Sequence[int], seed: int, batch_size: int
+) -> List[Tuple[int, int, int]]:
+    """The chunk coords for one batch index (its slice of the shuffled order)."""
+    shape = (int(bounds[0]), int(bounds[1]), int(bounds[2]))
+    n = shape[0] * shape[1] * shape[2]
+    start = batch_index * batch_size
+    out = []
+    for pos in range(start, min(start + batch_size, n)):
+        x, y, z = np.unravel_index(permute(pos, n, seed), shape)
+        out.append((int(x), int(y), int(z)))
+    return out
+
+
+def coord_to_batch_index(
+    coord: Sequence[int], bounds: Sequence[int], seed: int, batch_size: int
+) -> int:
+    """Which batch a chunk coord belongs to (for failed-index inspection)."""
+    shape = (int(bounds[0]), int(bounds[1]), int(bounds[2]))
+    n = shape[0] * shape[1] * shape[2]
+    flat = int(np.ravel_multi_index((int(coord[0]), int(coord[1]), int(coord[2])), shape))
+    return unpermute(flat, n, seed) // batch_size

--- a/pychunkedgraph/pipeline/ingest/__init__.py
+++ b/pychunkedgraph/pipeline/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""Ingest workload for the chunk-batch pipeline.
+
+Builds L2 atomic-edge chunks and parent-layer agglomerations, each under a
+per-chunk Bigtable lock. Run as a module: ``python -m pychunkedgraph.pipeline.ingest``.
+"""

--- a/pychunkedgraph/pipeline/ingest/__main__.py
+++ b/pychunkedgraph/pipeline/ingest/__main__.py
@@ -1,0 +1,8 @@
+"""Container entrypoint: ``python -m pychunkedgraph.pipeline.ingest``."""
+
+import sys
+
+from .worker import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pychunkedgraph/pipeline/ingest/dispatch.py
+++ b/pychunkedgraph/pipeline/ingest/dispatch.py
@@ -1,0 +1,46 @@
+"""Branch-aware shim: run one chunk's ingest body.
+
+The ONLY branch-specific piece of this package. `main` builds L2 atomic chunks
+via `add_atomic_edges` and parents via `add_layer`. The pcgv3 variant (OCDBT +
+`create_parent_chunk` modes) is added here when the package is ported; the rest
+of the package is identical across branches.
+"""
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Sequence
+
+import numpy as np
+
+from ...ingest.common import get_atomic_chunk_data
+from ...ingest.ran_agglomeration import get_active_edges
+from ...ingest.create.atomic_layer import add_atomic_edges
+from ...ingest.create.abstract_layers import add_layer
+
+
+@dataclass
+class IngestConfig:
+    """Minimal atomic-chunk source config: agglomeration path + raw-input flags."""
+
+    AGGLOMERATION: str = None
+    USE_RAW_EDGES: bool = False
+    USE_RAW_COMPONENTS: bool = False
+
+
+def process_chunk(
+    cg, layer: int, coord: Sequence[int], config: IngestConfig, n_threads: int = 1
+) -> None:
+    """Ingest a single chunk: L2 atomic edges, or L>2 parent agglomeration."""
+    coord = np.array(list(coord), dtype=int)
+    if layer == 2:
+        _add_atomic_chunk(cg, coord, config)
+    else:
+        add_layer(cg, layer, coord, n_threads=n_threads)
+
+
+def _add_atomic_chunk(cg, coord: np.ndarray, config: IngestConfig) -> None:
+    # get_atomic_chunk_data only needs .config/.cg/.cg_meta — no Redis-backed manager.
+    manager = SimpleNamespace(config=config, cg=cg, cg_meta=cg.meta)
+    chunk_edges_all, mapping = get_atomic_chunk_data(manager, coord)
+    chunk_edges_active, isolated_ids = get_active_edges(chunk_edges_all, mapping)
+    add_atomic_edges(cg, coord, chunk_edges_active, isolated=isolated_ids)

--- a/pychunkedgraph/pipeline/ingest/setup.py
+++ b/pychunkedgraph/pipeline/ingest/setup.py
@@ -1,0 +1,54 @@
+"""One-shot ingest setup — create the Bigtable table and write graph meta.
+
+Run once per graph, inside the image, before any layer Jobs:
+    python -m pychunkedgraph.pipeline.ingest.setup <graph_id> [--raw]
+
+Reads the dataset yaml from its mounted location (no path passed); this is the
+only step that touches the yaml. Folds the agglomeration source into
+``meta.custom_data["agg"] = {"path": str, "raw": bool}`` so workers read
+everything from Bigtable at run time — no yaml, no Redis. Errors out if the
+table already exists (the operator runs setup explicitly once).
+"""
+
+import argparse
+from os import environ
+
+import yaml
+
+from ...graph import ChunkedGraph
+from ...graph.client import BackendClientInfo
+from ...graph.client.bigtable import BigTableConfig
+from ...graph.meta import ChunkedGraphMeta, DataSource, GraphConfig
+
+# Predetermined mount path of the dataset yaml (the chart mounts the dataset
+# ConfigMap here); overridable for local/testing.
+DATASET_PATH = environ.get("PCG_DATASET", "/app/datasets/dataset.yml")
+
+
+def setup(graph_id: str, raw: bool = False, dataset_path: str = DATASET_PATH) -> None:
+    with open(dataset_path) as stream:
+        config = yaml.safe_load(stream)
+    client_config = BigTableConfig(**config["backend_client"]["CONFIG"])
+    client_info = BackendClientInfo(config["backend_client"]["TYPE"], client_config)
+    graph_config = GraphConfig(ID=str(graph_id), OVERWRITE=False, **config["graph_config"])
+    data_source = DataSource(**config["data_source"])
+    agg = {"path": config.get("ingest_config", {}).get("AGGLOMERATION"), "raw": raw}
+    meta = ChunkedGraphMeta(graph_config, data_source, custom_data={"agg": agg})
+    cg = ChunkedGraph(meta=meta, client_info=client_info)
+    cg.create()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="pychunkedgraph.pipeline.ingest.setup")
+    parser.add_argument("graph_id")
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="raw agglomeration input; the L2 workers convert it to processed data",
+    )
+    args = parser.parse_args()
+    setup(args.graph_id, raw=args.raw)
+
+
+if __name__ == "__main__":
+    main()

--- a/pychunkedgraph/pipeline/ingest/worker.py
+++ b/pychunkedgraph/pipeline/ingest/worker.py
@@ -1,0 +1,130 @@
+"""Ingest per-chunk processor: a Bigtable lock + renew heartbeat around dispatch.
+
+Each chunk is claimed under a per-chunk lock (skip if already done, defer if held
+live by another worker), processed via the branch-aware dispatch, then marked done
+only if we still hold the claim. Plugged into the generic ``pipeline.worker`` harness.
+"""
+
+import logging
+import os
+import threading
+import time
+from datetime import timedelta
+
+from .. import lock
+from ..exit_codes import FatalChunkError
+from ..worker import run
+from .dispatch import IngestConfig
+from . import dispatch
+
+logger = logging.getLogger(__name__)
+
+
+def _token() -> int:
+    return int.from_bytes(os.urandom(8), "big")
+
+
+def _atomic_config(cg) -> IngestConfig:
+    """Atomic-layer config from stored meta (set by setup) — never yaml/env.
+
+    The agglomeration source lives in ``meta.custom_data["agg"]`` as
+    ``{"path": str, "raw": bool}`` (everything else is in ``data_source``).
+    """
+    agg = cg.meta.custom_data.get("agg", {})
+    raw = bool(agg.get("raw", False))
+    return IngestConfig(
+        AGGLOMERATION=agg.get("path"),
+        USE_RAW_EDGES=raw,
+        USE_RAW_COMPONENTS=raw,
+    )
+
+
+def _expiry(layer: int, scale: float) -> timedelta:
+    """Per-layer lock TTL (L2 = 3 min, +3 min per layer) times a user scale factor.
+
+    The renew heartbeat keeps a live worker's claim fresh, so this only bounds how
+    long a *dead* worker's chunk stays locked before retry — short for cheap L2.
+    """
+    return timedelta(minutes=3 * (layer - 1) * scale)
+
+
+def _renew_loop(table, chunk_id, token, interval, stop):
+    """Keep our claim fresh while the chunk runs; exits on `stop` or if the claim is lost."""
+    while not stop.wait(interval):
+        if not lock.renew(table, chunk_id, token):
+            logger.warning(f"chunk {chunk_id} claim renew failed")
+            return
+
+
+def make_processor(cg, layer, env):
+    """Build the ingest per-chunk processor for this batch (binds lock + config)."""
+    table = cg.client._table
+    config = _atomic_config(cg) if layer == 2 else None
+    expiry = _expiry(layer, float(os.environ.get("PCG_LOCK_EXPIRY_SCALE", 1)))
+    opts = {
+        "n_threads": env["n_threads"],
+        "expiry": expiry,
+        "renew": expiry.total_seconds() / 3,
+        "poll": float(os.environ.get("PCG_LOCK_POLL_SEC", 10)),
+        "held_max_wait": float(os.environ.get("PCG_HELD_MAX_WAIT_SEC", 120)),
+    }
+
+    def process_one(coord):
+        return _process_one(table, cg, layer, coord, config, opts)
+
+    return process_one
+
+
+def _process_one(table, cg, layer, coord, config, opts) -> str:
+    """Returns 'done' | 'ok' | 'transient' | 'fatal' for one chunk."""
+    chunk_id = int(cg.get_chunk_id(layer=layer, x=coord[0], y=coord[1], z=coord[2]))
+    token = _token()
+
+    deadline = time.monotonic() + opts["held_max_wait"]
+    while True:
+        state = lock.acquire(table, chunk_id, token, opts["expiry"])
+        if state == lock.DONE:
+            return "done"
+        if state == lock.ACQUIRED:
+            break
+        if time.monotonic() >= deadline:  # someone else holds it; let the batch retry
+            logger.warning(f"chunk {layer}_{tuple(coord)} held by another worker; deferring")
+            return "transient"
+        time.sleep(opts["poll"])
+
+    # Renew the claim while we work so a live worker's in-progress chunk never goes
+    # stale — no other worker can start a chunk still being processed. Only a dead
+    # worker (heartbeat stopped) lets the claim expire, after which retry is safe.
+    stop = threading.Event()
+    heartbeat = threading.Thread(
+        target=_renew_loop, args=(table, chunk_id, token, opts["renew"], stop), daemon=True
+    )
+    heartbeat.start()
+    try:
+        dispatch.process_chunk(cg, layer, coord, config, n_threads=opts["n_threads"])
+        outcome = "ok"
+    except FatalChunkError:
+        logger.exception(f"fatal chunk {layer}_{tuple(coord)}")
+        outcome = "fatal"
+    except Exception:
+        logger.exception(f"transient failure on chunk {layer}_{tuple(coord)}")
+        outcome = "transient"
+    finally:
+        stop.set()
+        heartbeat.join()
+
+    if outcome != "ok":
+        lock.release(table, chunk_id, token)
+        return outcome
+    if lock.mark_done(table, chunk_id, token):
+        return "ok"
+    logger.warning(f"chunk {layer}_{tuple(coord)} claim lost before done; deferring")
+    return "transient"
+
+
+def main() -> int:
+    return run(make_processor)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pychunkedgraph/pipeline/lock.py
+++ b/pychunkedgraph/pipeline/lock.py
@@ -1,0 +1,107 @@
+"""Self-contained per-chunk lock on Bigtable: at most one effective writer per chunk.
+
+A dedicated, hash-prefixed lock row per chunk_id holds two cells in the
+Concurrency family: a ``claim`` (token + cell-timestamp, expiry-based) and a
+``done`` marker. Acquire/mark-done/renew/release are atomic ``conditional_row``
+CAS ops mirroring ``BigTableClient.lock_root``. All writes are value-matched on
+the claim token (a fence) so a zombie whose claim was stolen cannot mark done.
+Family "0" keeps all cell versions, so token/freshness checks look only at the
+latest claim via ``CellsColumnLimitFilter(1)``.
+"""
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+from google.cloud.bigtable.row_filters import (
+    CellsColumnLimitFilter,
+    ColumnRangeFilter,
+    RowFilterChain,
+    RowFilterUnion,
+    TimestampRange,
+    TimestampRangeFilter,
+    ValueRangeFilter,
+)
+
+ACQUIRED = "acquired"
+DONE = "done"
+HELD = "held"
+
+_FAMILY = "0"
+_CLAIM = b"claim"
+_DONE = b"done"
+
+
+def _row_key(chunk_id: int) -> bytes:
+    packed = int(chunk_id).to_bytes(8, "big")
+    return hashlib.blake2b(packed, digest_size=2).digest() + packed
+
+
+def _b(token: int) -> bytes:
+    return int(token).to_bytes(8, "big")
+
+
+def _now() -> datetime:
+    """Bigtable-compatible 'now': UTC, rounded down to the millisecond."""
+    t = datetime.now(timezone.utc)
+    return t - timedelta(microseconds=t.microsecond % 1000)
+
+
+def _col(column: bytes) -> ColumnRangeFilter:
+    return ColumnRangeFilter(
+        _FAMILY, start_column=column, end_column=column,
+        inclusive_start=True, inclusive_end=True,
+    )
+
+
+def _claim_is(token: int) -> RowFilterChain:
+    """Latest claim cell exists and its value == token (the fence)."""
+    return RowFilterChain([_col(_CLAIM), CellsColumnLimitFilter(1),
+                           ValueRangeFilter(start_value=_b(token), end_value=_b(token),
+                                            inclusive_start=True, inclusive_end=True)])
+
+
+def _is_done(table, row_key: bytes) -> bool:
+    return table.read_row(row_key, filter_=_col(_DONE)) is not None
+
+
+def acquire(table, chunk_id: int, token: int, expiry: timedelta) -> str:
+    """Try to claim a chunk. Returns ACQUIRED, DONE (skip), or HELD (retry)."""
+    row_key = _row_key(chunk_id)
+    cutoff = _now() - expiry
+    fresh_claim = RowFilterChain(
+        [_col(_CLAIM), CellsColumnLimitFilter(1),
+         TimestampRangeFilter(TimestampRange(start=cutoff))]
+    )
+    base = RowFilterUnion([_col(_DONE), fresh_claim])
+    row = table.conditional_row(row_key, filter_=base)
+    # set_cell applies when the base condition is FALSE (no done, no live claim)
+    row.set_cell(_FAMILY, _CLAIM, _b(token), state=False,
+                 timestamp=_now())
+    blocked = row.commit()
+    if not blocked:
+        return ACQUIRED
+    return DONE if _is_done(table, row_key) else HELD
+
+
+def mark_done(table, chunk_id: int, token: int) -> bool:
+    """Mark a chunk done iff we still hold the claim. Returns False if fenced out."""
+    row = table.conditional_row(_row_key(chunk_id), filter_=_claim_is(token))
+    row.set_cell(_FAMILY, _DONE, _b(token), state=True,
+                 timestamp=_now())
+    row.delete_cell(_FAMILY, _CLAIM, state=True)
+    return bool(row.commit())
+
+
+def renew(table, chunk_id: int, token: int) -> bool:
+    """Extend our claim's expiry. Returns False if we no longer hold it."""
+    row = table.conditional_row(_row_key(chunk_id), filter_=_claim_is(token))
+    row.set_cell(_FAMILY, _CLAIM, _b(token), state=True,
+                 timestamp=_now())
+    return bool(row.commit())
+
+
+def release(table, chunk_id: int, token: int) -> None:
+    """Drop our claim (best-effort) so a sequential retry can re-claim before expiry."""
+    row = table.conditional_row(_row_key(chunk_id), filter_=_claim_is(token))
+    row.delete_cell(_FAMILY, _CLAIM, state=True)
+    row.commit()

--- a/pychunkedgraph/pipeline/meshing/__init__.py
+++ b/pychunkedgraph/pipeline/meshing/__init__.py
@@ -1,0 +1,6 @@
+"""Meshing workload for the chunk-batch pipeline.
+
+One-shot mesh-metadata setup, then per-layer mesh generation (L2 marching cubes,
+L>2 sharded stitching), idempotent (overwrites shards), no per-chunk lock. Run as a
+module: ``python -m pychunkedgraph.pipeline.meshing``.
+"""

--- a/pychunkedgraph/pipeline/meshing/__main__.py
+++ b/pychunkedgraph/pipeline/meshing/__main__.py
@@ -1,0 +1,8 @@
+"""Container entrypoint: ``python -m pychunkedgraph.pipeline.meshing``."""
+
+import sys
+
+from .worker import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pychunkedgraph/pipeline/meshing/meta.py
+++ b/pychunkedgraph/pipeline/meshing/meta.py
@@ -1,0 +1,68 @@
+"""MeshConfig dataclass — single source of truth for per-CG mesh setup values.
+
+Read from the dataset yaml under a ``mesh_config:`` block, exactly like
+``OcdbtConfig`` is read from ``ocdbt_config:``. Every static field is
+required — the helper that applies it (``setup_mesh_meta``) does not
+substitute defaults for missing yaml entries. The only optional field
+is :attr:`dynamic_mesh_dir`, which is graph-id-derived and filled in by
+:meth:`with_graph_id` when omitted from the yaml.
+
+Example yaml block::
+
+    mesh_config:
+      dir: graphene_meshes
+      mip: 0
+      max_layer: 6
+      max_error: 40
+      chunk_size: [512, 512, 256]
+      minishard_bits: {2: 1, 3: 3, 4: 6, 5: 9, 6: 12}
+      # dynamic_mesh_dir: my_custom_dir  # optional; default "dynamic_<graph_id>"
+"""
+
+from dataclasses import asdict, dataclass, replace
+from typing import Dict, List, Optional
+
+
+@dataclass
+class MeshConfig:
+    """Per-CG mesh setup config. See module docstring for yaml schema."""
+
+    dir: str
+    mip: int
+    max_layer: int
+    max_error: int
+    chunk_size: List[int]
+    minishard_bits: Dict[int, int]
+    dynamic_mesh_dir: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, d: Dict) -> "MeshConfig":
+        """Build from a yaml-parsed dict.
+
+        Unknown keys are dropped (so older yamls don't break newer code).
+        ``minishard_bits`` keys are coerced to ``int`` so the yaml is
+        tolerant of bare-int vs quoted-string keys.
+        """
+        if not d:
+            raise ValueError(
+                "MeshConfig.from_dict: empty config — yaml `mesh_config:` "
+                "block is required"
+            )
+        known = {f for f in cls.__dataclass_fields__}
+        kwargs = {k: v for k, v in d.items() if k in known}
+        if "minishard_bits" in kwargs:
+            kwargs["minishard_bits"] = {
+                int(k): int(v) for k, v in kwargs["minishard_bits"].items()
+            }
+        if "chunk_size" in kwargs:
+            kwargs["chunk_size"] = [int(x) for x in kwargs["chunk_size"]]
+        return cls(**kwargs)
+
+    def with_graph_id(self, graph_id: str) -> "MeshConfig":
+        """Return a copy with ``dynamic_mesh_dir`` filled in if unset."""
+        if self.dynamic_mesh_dir is not None:
+            return self
+        return replace(self, dynamic_mesh_dir=f"dynamic_{graph_id}")
+
+    def to_dict(self) -> Dict:
+        return asdict(self)

--- a/pychunkedgraph/pipeline/meshing/setup.py
+++ b/pychunkedgraph/pipeline/meshing/setup.py
@@ -1,0 +1,180 @@
+"""One-shot mesh metadata setup for a CG.
+
+Writes every mesh-related field a new or freshly-copied graph needs
+before any mesh fragment can be served:
+
+    1. ``cg.meta.ws_cv.info["mesh"]``  (mesh dir in the watershed cv info.json)
+    2. ``cg.meta.ws_cv.mesh.meta.info``  (per-layer sharded mesh spec)
+    3. ``cg.meta.ws_cv.info["mesh_metadata"]``  (uniform draco grid + dynamic dir)
+    4. ``cg.meta.custom_data["mesh"]``  (CG bigtable meta block)
+
+Idempotent: re-running overwrites the same fields with the current
+inputs, with one exception — ``initial_ts`` is preserved if already
+set, because changing it after the fact would reclassify every node
+id and silently break served manifests.
+
+Also the container entrypoint, run once per graph after root-layer ingest:
+
+    python -m pychunkedgraph.pipeline.meshing.setup <graph_id>
+
+reads ``mesh_config:`` from the mounted dataset yaml (``PCG_DATASET``).
+"""
+
+import argparse
+import logging
+from os import environ
+
+import numpy as np
+import yaml
+
+from ...graph.chunkedgraph import ChunkedGraph
+from ...meshing.meshgen import get_draco_encoding_settings_for_chunk
+from .meta import MeshConfig
+
+logger = logging.getLogger(__name__)
+
+# Predetermined mount path of the dataset yaml (the chart mounts the dataset
+# ConfigMap here); overridable for local/testing.
+DATASET_PATH = environ.get("PCG_DATASET", "/app/datasets/dataset.yml")
+
+
+def derive_initial_ts(cg: ChunkedGraph) -> int:
+    """Unix-seconds timestamp of a root id sampled from the dataset center.
+
+    ``mesh.initial_ts`` is the threshold ``segregate_node_ids`` (see
+    ``meshing/manifest/utils.py``) uses to classify root ids as initial
+    vs post-ingest. It must sit above the last initial-ingest commit
+    and below any post-ingest commit. Picking a root id near the
+    volume center and using its commit timestamp satisfies both bounds
+    for any graph that completed initial ingest.
+
+    Walks shells outward from the center of the L2 chunk grid (L1
+    shares L2's coordinate grid) and returns the timestamp of the root
+    of the first SV found.
+    """
+    hi = np.asarray(cg.meta.layer_chunk_bounds[2])
+    center = hi // 2
+    for r in range(int(hi.max()) + 1):
+        box = (
+            np.array(
+                np.meshgrid(
+                    np.arange(-r, r + 1),
+                    np.arange(-r, r + 1),
+                    np.arange(-r, r + 1),
+                    indexing="ij",
+                )
+            )
+            .reshape(3, -1)
+            .T
+        )
+        shell = box[np.max(np.abs(box), axis=1) == r]
+        coords = np.unique(np.clip(center + shell, 0, hi - 1), axis=0)
+        for c in coords:
+            chunk_id = cg.get_chunk_id(layer=1, x=int(c[0]), y=int(c[1]), z=int(c[2]))
+            svs = list(cg.range_read_chunk(chunk_id))
+            if svs:
+                sv = svs[len(svs) // 2]
+                root = cg.get_root(sv)
+                ts = cg.get_node_timestamps(np.array([root]), return_numpy=False)[0]
+                return int(ts.timestamp())
+    raise RuntimeError("derive_initial_ts: no SVs found anywhere in the volume")
+
+
+def setup_mesh_meta(
+    cg: ChunkedGraph,
+    mesh_config: MeshConfig,
+) -> dict:
+    """Write every mesh.* metadata field this graph needs to serve meshes.
+
+    Writes go to two places: the watershed CloudVolume (steps 1-3, via
+    ``info.json`` / ``mesh/info`` on GCS) and the CG's bigtable meta
+    block (step 4).
+
+    ``initial_ts`` is set once and never overwritten — if the existing
+    bigtable mesh meta already has one, it is reused as-is. Otherwise
+    it is derived via :func:`derive_initial_ts` and persisted.
+
+    Returns the mesh meta dict persisted into bigtable.
+    """
+    cfg = mesh_config.with_graph_id(cg.graph_id)
+    existing_mesh = cg.meta.custom_data.get("mesh", {})
+    existing_ts = existing_mesh.get("initial_ts")
+    initial_ts = int(existing_ts) if existing_ts is not None else derive_initial_ts(cg)
+    if existing_ts is not None:
+        logger.info("preserving existing initial_ts=%d", initial_ts)
+
+    # 1. watershed CV info — mesh dir.
+    cg.meta.ws_cv.info["mesh"] = cfg.dir
+    cg.meta.ws_cv.commit_info()
+    logger.info("wrote ws_cv.info['mesh']=%r", cfg.dir)
+
+    # 2. sharded mesh spec — same template per layer, layer-specific bits.
+    layer_shard_spec = {
+        "@type": "neuroglancer_uint64_sharded_v1",
+        "preshift_bits": 0,
+        "hash": "murmurhash3_x86_128",
+        "shard_bits": 0,
+        "minishard_index_encoding": "gzip",
+        "data_encoding": "raw",
+    }
+    sharding = {
+        str(layer): {**layer_shard_spec, "minishard_bits": int(bits)}
+        for layer, bits in cfg.minishard_bits.items()
+        if layer <= cfg.max_layer
+    }
+    mesh_spec = {
+        "@type": "neuroglancer_legacy_mesh",
+        "spatial_index": None,
+        "mip": int(cfg.mip),
+        "chunk_size": list(cfg.chunk_size),
+        "sharding": sharding,
+    }
+    cg.meta.ws_cv.mesh.meta.info = mesh_spec
+    cg.meta.ws_cv.mesh.meta.commit_info()
+    logger.info("wrote sharded mesh spec for layers %s", sorted(sharding.keys()))
+
+    # 3. uniform draco grid size, derived from layer-2 draco settings.
+    draco = get_draco_encoding_settings_for_chunk(
+        cg, cg.get_chunk_id(layer=2, x=0, y=0, z=0), mip=cfg.mip
+    )
+    grid_size = draco["quantization_range"] / (2 ** draco["quantization_bits"] - 1)
+    cg.meta.ws_cv.info["mesh_metadata"] = {
+        "uniform_draco_grid_size": grid_size,
+        "unsharded_mesh_dir": "dynamic",
+    }
+    cg.meta.ws_cv.commit_info()
+    logger.info("wrote mesh_metadata uniform_draco_grid_size=%s", grid_size)
+
+    # 4. CG-side bigtable meta block.
+    mesh_meta = {
+        "max_layer": int(cfg.max_layer),
+        "dynamic_mesh_dir": cfg.dynamic_mesh_dir,
+        "mip": int(cfg.mip),
+        "max_error": int(cfg.max_error),
+        "dir": cfg.dir,
+        "initial_ts": int(initial_ts),
+    }
+    cg.meta.custom_data["mesh"] = mesh_meta
+    cg.update_meta(cg.meta, overwrite=True)
+    logger.info("wrote cg.meta.custom_data['mesh']=%r", mesh_meta)
+    return mesh_meta
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="pychunkedgraph.pipeline.meshing.setup")
+    parser.add_argument("graph_id")
+    args = parser.parse_args()
+    with open(DATASET_PATH) as stream:
+        config = yaml.safe_load(stream)
+    if "mesh_config" not in config:
+        raise SystemExit(
+            f"{DATASET_PATH} has no `mesh_config:` block — required for mesh meta setup."
+        )
+    mesh_cfg = MeshConfig.from_dict(config["mesh_config"])
+    cg = ChunkedGraph(graph_id=args.graph_id)
+    result = setup_mesh_meta(cg, mesh_cfg)
+    print(f"mesh meta written for {args.graph_id}: {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pychunkedgraph/pipeline/meshing/worker.py
+++ b/pychunkedgraph/pipeline/meshing/worker.py
@@ -1,0 +1,48 @@
+"""Mesh per-chunk processor: marching cubes at L2, sharded stitching above.
+
+Mirrors ``meshing_sqs.MeshTask.execute``. Idempotent (overwrites shards), so it
+needs no per-chunk lock. Plugged into the generic ``pipeline.worker`` harness. ``mip``
+comes from the mesh meta written by setup; a per-chunk failure counts transient so
+the batch retries it.
+"""
+
+import logging
+import os
+
+from ...meshing import meshgen
+from ..worker import run
+
+logger = logging.getLogger(__name__)
+
+
+def make_processor(cg, layer, env):
+    """Build the mesh per-chunk processor for this batch."""
+    mesh_meta = cg.meta.custom_data.get("mesh") or {}
+    mip = int(mesh_meta.get("mip", 0))
+    cache = os.environ.get("PCG_MESH_CACHE", "1") != "0"
+
+    def process_one(coord):
+        chunk_id = int(cg.get_chunk_id(layer=layer, x=coord[0], y=coord[1], z=coord[2]))
+        try:
+            if layer == 2:
+                meshgen.chunk_initial_mesh_task(
+                    cg.graph_id, chunk_id, None, mip=mip, sharded=True, cache=cache
+                )
+            else:
+                meshgen.chunk_initial_sharded_stitching_task(
+                    cg.graph_id, chunk_id, mip, cache=cache
+                )
+            return "ok"
+        except Exception:
+            logger.exception(f"mesh failure on chunk {layer}_{tuple(coord)}")
+            return "transient"
+
+    return process_one
+
+
+def main() -> int:
+    return run(make_processor)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pychunkedgraph/pipeline/worker.py
+++ b/pychunkedgraph/pipeline/worker.py
@@ -1,0 +1,71 @@
+"""Generic one-shot batch-worker harness — the container entrypoint skeleton.
+
+A workload calls ``run(make_processor)``: this reads the Indexed-Job env contract,
+maps JOB_COMPLETION_INDEX to a batch of scattered chunk coords, and runs each
+through the workload's per-chunk processor, returning an exit code for the Job's
+podFailurePolicy. No Redis, no yaml — the graph is read from Bigtable by graph id.
+
+``make_processor(cg, layer, env) -> process_one``; ``process_one(coord)`` returns
+``"ok" | "done" | "transient" | "fatal"``.
+"""
+
+import logging
+import os
+
+from ..graph.chunkedgraph import ChunkedGraph
+from . import grid
+from .exit_codes import FATAL, SUCCESS, TRANSIENT
+
+logger = logging.getLogger(__name__)
+NOTE = logging.INFO + 5  # progress level above other libs' INFO so they stay quiet
+logging.addLevelName(NOTE, "NOTE")
+
+
+def layer_bounds(cg, layer: int):
+    """(X,Y,Z) chunk grid for a layer; the root layer is a single chunk."""
+    if layer == cg.meta.layer_count:
+        return (1, 1, 1)
+    return cg.meta.layer_chunk_bounds[layer]
+
+
+def run(make_processor) -> int:
+    """Run one batch index for the configured layer; returns a process exit code."""
+    logging.basicConfig(level=NOTE)
+    env = {
+        "graph_id": os.environ["PCG_GRAPH_ID"],
+        "layer": int(os.environ["PCG_LAYER"]),
+        "seed": int(os.environ["PCG_PERM_SEED"]),
+        "batch_size": int(os.environ["PCG_BATCH_SIZE"]),
+        "index": int(os.environ["JOB_COMPLETION_INDEX"]),
+        "n_threads": int(os.environ.get("PCG_N_THREADS", 1)),
+    }
+    layer, index = env["layer"], env["index"]
+
+    # One ChunkedGraph per pod, reused for the whole batch: the meta row is read
+    # once here (not per chunk) so it never hot-rows.
+    cg = ChunkedGraph(graph_id=env["graph_id"])
+    process_one = make_processor(cg, layer, env)
+
+    coords = grid.batch_coords(index, layer_bounds(cg, layer), env["seed"], env["batch_size"])
+    logger.log(NOTE, f"layer {layer} batch {index}: {len(coords)} chunks")
+
+    fatal = transient = 0
+    for coord in coords:
+        outcome = process_one(coord)
+        if outcome == "fatal":
+            fatal += 1
+        elif outcome == "transient":
+            transient += 1
+
+    logger.log(
+        NOTE,
+        f"layer {layer} batch {index} done: {len(coords) - fatal - transient} ok, "
+        f"{transient} transient, {fatal} fatal",
+    )
+    # Retry the batch while any chunk is transiently unfinished (done ones skip);
+    # only FailIndex once nothing but fatal chunks remain.
+    if transient:
+        return TRANSIENT
+    if fatal:
+        return FATAL
+    return SUCCESS

--- a/pychunkedgraph/tests/test_pipeline_grid.py
+++ b/pychunkedgraph/tests/test_pipeline_grid.py
@@ -1,0 +1,56 @@
+"""Pure unit tests for the Indexed-Job chunk permutation (no external deps)."""
+
+import numpy as np
+
+from ..pipeline import grid
+
+
+def _all_coords(bounds, seed, batch_size):
+    n = bounds[0] * bounds[1] * bounds[2]
+    coords = []
+    for i in range(grid.num_batches(n, batch_size)):
+        coords.extend(grid.batch_coords(i, bounds, seed, batch_size))
+    return coords
+
+
+def test_permutation_is_bijection():
+    for n in [1, 2, 7, 64, 100, 513, 1000]:
+        assert sorted(grid.permute(p, n, seed=42) for p in range(n)) == list(range(n))
+
+
+def test_permute_unpermute_inverse():
+    n, seed = 1000, 7
+    assert all(grid.unpermute(grid.permute(p, n, seed), n, seed) == p for p in range(n))
+
+
+def test_deterministic_per_seed():
+    n = 257
+    assert [grid.permute(p, n, 123) for p in range(n)] == [
+        grid.permute(p, n, 123) for p in range(n)
+    ]
+    assert [grid.permute(p, n, 123) for p in range(n)] != [
+        grid.permute(p, n, 124) for p in range(n)
+    ]
+
+
+def test_batches_partition_grid_exactly():
+    bounds, seed, batch_size = (4, 5, 3), 99, 7  # n = 60
+    coords = _all_coords(bounds, seed, batch_size)
+    assert len(coords) == 60
+    assert len(set(coords)) == 60
+    assert all(0 <= x < 4 and 0 <= y < 5 and 0 <= z < 3 for x, y, z in coords)
+
+
+def test_coord_to_batch_index_roundtrip():
+    bounds, seed, batch_size = (4, 5, 3), 99, 7
+    for i in range(grid.num_batches(60, batch_size)):
+        for coord in grid.batch_coords(i, bounds, seed, batch_size):
+            assert grid.coord_to_batch_index(coord, bounds, seed, batch_size) == i
+
+
+def test_batch_is_scattered_not_contiguous():
+    bounds, seed, batch_size = (16, 16, 16), 5, 16
+    coords = grid.batch_coords(0, bounds, seed, batch_size)
+    flats = sorted(int(np.ravel_multi_index(c, bounds)) for c in coords)
+    # a contiguous raster block would span batch_size-1; scattered spans far wider
+    assert flats[-1] - flats[0] > 4 * batch_size


### PR DESCRIPTION
## Add `pychunkedgraph.pipeline` — cross-branch chunk-batch core (ingest + meshing)

Adds a self-contained `pychunkedgraph/pipeline/` package that runs chunk-grid workloads (**ingest**, **meshing**) as stock Kubernetes **Indexed Jobs** — no Redis/RQ, no scheduler. This is the worker side of the new GKE Autopilot orchestration in CAVEpipelines; each workload is a module entrypoint the pipeline image runs.

### Layout
```
pychunkedgraph/pipeline/
  grid.py          # fixed-seed scatter (Feistel permutation): batch index -> scattered coords
  lock.py          # per-chunk Bigtable claim/done CAS (token-fenced; one writer per chunk)
  exit_codes.py    # SUCCESS / TRANSIENT / FATAL — mapped to the Job podFailurePolicy
  worker.py        # generic harness: run(make_processor) -> exit code
  ingest/          # dispatch (branch shim) + setup (table+meta) + worker (lock+heartbeat)
  meshing/         # meta (MeshConfig) + setup (mesh-metadata) + worker (marching cubes / stitching)
```

### Entrypoints (run in the container)
```
python -m pychunkedgraph.pipeline.ingest              # ingest worker
python -m pychunkedgraph.pipeline.ingest.setup <id>   # create table + graph meta
python -m pychunkedgraph.pipeline.meshing             # mesh worker (L2 cubes / L>2 stitching)
python -m pychunkedgraph.pipeline.meshing.setup <id>  # one-shot mesh metadata
```
Workers read the Indexed-Job env contract (`JOB_COMPLETION_INDEX`, `PCG_GRAPH_ID/LAYER/PERM_SEED/BATCH_SIZE`), map the index to a scattered batch of chunk coords, and process each — ingest under a per-chunk lock, meshing idempotently (no lock). Graph state is read from Bigtable by graph id (no yaml/Redis at run time).

### Design notes
- **Self-contained**: depends on the rest of the repo only for the actual chunk-compute functions (`add_atomic_edges`/`add_layer`, `get_atomic_chunk_data`/`get_active_edges`, `meshgen.*`) and core `graph.*` classes. Config and setup live in the package (minimal `IngestConfig`, inlined meta build — no `IngestConfig`/`bootstrap` from `ingest/`).
- **Branch-portable**: the only branch-specific file is `pipeline/ingest/dispatch.py` (the chunk-body shim). On `pcgv3` it needs a variant using that branch's chunk bodies (called out in the file docstring + `pipeline/README.md`); everything else cherry-picks unchanged.
- **Additive**: no existing modules touched; `pipeline` is not auto-imported by the top-level package, so existing imports/tests are unaffected.

### Tests
`tests/test_pipeline_grid.py` — pure unit tests for the permutation (bijection, invertibility, scatter, batch partition). Lock/worker are validated against the Bigtable emulator outside the committed suite, keeping the package importable on branches without that fixture.

### Follow-up
Consumed by the CAVEpipelines PR (the `pipeline` CLI builds Indexed Jobs that run these entrypoints).
